### PR TITLE
Feat/fuzzy matching is too broad

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,12 @@ Deja auto-spawns its daemon on first use and keeps it running across sessions.
 |---|---|
 | `→` (right arrow) | Accept full suggestion |
 | `Ctrl+→` | Accept next word only |
+| `Shift+→` | Cycle fuzzy preset forward (tight → smart → loose) |
+| `Shift+←` | Cycle fuzzy preset backward (loose → smart → tight) |
 | `Tab` | Open inline alternatives picker |
 | `Ctrl+X` | Suppress current suggestion |
+
+> Accept the ghost suggestion with `→`, not `Enter`. `Enter` executes whatever's literally in your buffer; `→` is what commits the ghost into the buffer first.
 
 ---
 
@@ -108,7 +112,17 @@ Change the preset on the fly (takes effect immediately, persists across restarts
 ```bash
 deja fuzzy           # show current preset + examples
 deja fuzzy tight     # set the preset
+deja fuzzy cycle     # advance to the next preset  (tight → smart → loose → tight)
+deja fuzzy back      # step to the previous preset (loose → smart → tight → loose)
 ```
+
+Or cycle without leaving the line — press `Shift+→` (forward) or `Shift+←` (backward) at any prompt and the next preset is applied immediately. The ghost suggestion repaints under the new mode in the same frame, and a picker-style confirmation appears below the prompt showing where you are in the ladder:
+
+```
+deja: fuzzy    tight    *smart*    loose
+```
+
+Rebind via `DEJA_CYCLE_FUZZY_KEY` / `DEJA_CYCLE_FUZZY_BACK_KEY` (set either to empty to disable that direction; tmux users may need `set -g xterm-keys on` for the default Shift+arrow sequences to pass through).
 
 Or override per shell session via environment variable:
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,31 @@ Deja auto-spawns its daemon on first use and keeps it running across sessions.
 
 ---
 
+## Tuning fuzziness
+
+Deja's matcher accepts any in-order subsequence of the characters you've typed. By default it stops the typed letters from sprawling too far apart in a candidate — `gco` will match `git checkout`, but won't match `git remote add origin`. Pick a preset to tune that strictness:
+
+| Preset  | Behavior | Example: typing `gco` |
+|---------|----------|------------------------|
+| `loose` | typed letters can be far apart (up to 8 chars between) | `gco` → `git checkout -- README` |
+| `smart` | typed letters stay close together (up to 4 chars between) — **default** | `gco` → `git checkout main` |
+| `tight` | typed letters must be near-adjacent (up to 1 char between) | `gco` → `gco`, `g.co`, `gc.o` |
+
+Change the preset on the fly (takes effect immediately, persists across restarts):
+
+```bash
+deja fuzzy           # show current preset + examples
+deja fuzzy tight     # set the preset
+```
+
+Or override per shell session via environment variable:
+
+```bash
+export DEJA_FUZZY=smart   # before the daemon starts; takes precedence over the saved preset
+```
+
+---
+
 ## Troubleshooting
 
 Every subcommand supports `--help` (e.g. `deja query --help`) for flag-level details. The most common issues:

--- a/cmd/deja/daemon.go
+++ b/cmd/deja/daemon.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/giammarcoferranti/deja/internal/config"
 	"github.com/giammarcoferranti/deja/internal/daemon"
 	"github.com/giammarcoferranti/deja/internal/store"
 )
@@ -52,6 +53,15 @@ func runDaemon(args []string) {
 		os.Exit(1)
 	}
 
+	cfgDir, err := dataDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "deja daemon: %v\n", err)
+		os.Exit(1)
+	}
+	fuzzy, src := config.LoadFuzzy(cfgDir)
+	state.SetFuzzy(fuzzy)
+	fmt.Fprintf(os.Stderr, "deja daemon: fuzzy=%s (%s)\n", fuzzy, sourceLabel(src))
+
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
@@ -59,5 +69,16 @@ func runDaemon(args []string) {
 	if err := daemon.Serve(ctx, state, sock); err != nil {
 		fmt.Fprintf(os.Stderr, "deja daemon: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+func sourceLabel(s config.Source) string {
+	switch s {
+	case config.SourceEnv:
+		return "DEJA_FUZZY"
+	case config.SourceFile:
+		return "config file"
+	default:
+		return "default"
 	}
 }

--- a/cmd/deja/fuzzy.go
+++ b/cmd/deja/fuzzy.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/giammarcoferranti/deja/internal/config"
+	"github.com/giammarcoferranti/deja/internal/daemon"
+	"github.com/giammarcoferranti/deja/internal/scorer"
+)
+
+func runFuzzy(args []string) {
+	fs := flag.NewFlagSet("fuzzy", flag.ContinueOnError)
+	fs.Usage = func() {
+		w := os.Stdout
+		fs.SetOutput(w)
+		fmt.Fprintln(w, "deja fuzzy — show or change the fuzzy strictness preset")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Usage:")
+		fmt.Fprintln(w, "  deja fuzzy                 show the current preset and examples")
+		fmt.Fprintln(w, "  deja fuzzy <preset>        set the preset (loose|smart|tight)")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "The preset controls how far apart typed letters may be in a candidate")
+		fmt.Fprintln(w, "command. Changes take effect immediately if the daemon is running, and")
+		fmt.Fprintln(w, "are persisted to ~/.local/share/deja/config so they survive restarts.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Override at session level with: export DEJA_FUZZY=smart")
+	}
+	parseFlags(fs, args)
+
+	rest := fs.Args()
+	switch len(rest) {
+	case 0:
+		current := readCurrentFuzzy()
+		printFuzzyHelp(current, nil)
+	case 1:
+		setFuzzy(rest[0])
+	default:
+		fmt.Fprintln(os.Stderr, "deja fuzzy: too many arguments")
+		printFuzzyHelp(readCurrentFuzzy(), nil)
+		os.Exit(2)
+	}
+}
+
+// readCurrentFuzzy returns the effective preset. Prefer asking the daemon (it
+// knows the live in-memory value); fall back to the persisted file + env.
+func readCurrentFuzzy() scorer.Fuzzy {
+	if resp, err := dialGetConfig(); err == nil {
+		if f, perr := scorer.ParseFuzzy(resp.Fuzzy); perr == nil {
+			return f
+		}
+	}
+	dir, err := dataDir()
+	if err != nil {
+		return scorer.FuzzyDefault
+	}
+	f, _ := config.LoadFuzzy(dir)
+	return f
+}
+
+func setFuzzy(raw string) {
+	f, err := scorer.ParseFuzzy(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "deja fuzzy: %v\n", err)
+		printFuzzyHelp(readCurrentFuzzy(), nil)
+		os.Exit(2)
+	}
+
+	dir, err := dataDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "deja fuzzy: %v\n", err)
+		os.Exit(1)
+	}
+	prev, _ := config.LoadFuzzy(dir)
+
+	if err := config.SaveFuzzy(dir, f); err != nil {
+		fmt.Fprintf(os.Stderr, "deja fuzzy: persist: %v\n", err)
+		os.Exit(1)
+	}
+
+	daemonApplied := false
+	if _, derr := dialSetConfig(daemon.SetConfigReq{Fuzzy: f.String()}); derr == nil {
+		daemonApplied = true
+	}
+
+	if prev == f {
+		fmt.Printf("fuzzy: %s (unchanged)\n", f)
+	} else {
+		fmt.Printf("fuzzy: %s → %s\n", prev, f)
+	}
+	if !daemonApplied {
+		fmt.Println("note: daemon not reachable; new preset will apply on next start")
+	}
+	if env := strings.TrimSpace(os.Getenv(config.EnvFuzzy)); env != "" && env != f.String() {
+		fmt.Printf("note: DEJA_FUZZY=%s is set in your environment and will override on next daemon start\n", env)
+	}
+}
+
+func printFuzzyHelp(current scorer.Fuzzy, _ error) {
+	mark := func(p scorer.Fuzzy) string {
+		if p == current {
+			return "*"
+		}
+		return " "
+	}
+	fmt.Printf("current: %s\n\n", current)
+	fmt.Printf("  %s loose   typed letters can be far apart (up to 8 chars between)\n", mark(scorer.FuzzyLoose))
+	fmt.Printf("            e.g. `gco` → `git checkout -- README`\n")
+	fmt.Printf("  %s smart   typed letters stay close together (up to 4 chars between)   [default]\n", mark(scorer.FuzzySmart))
+	fmt.Printf("            e.g. `gco` → `git checkout main`\n")
+	fmt.Printf("  %s tight   typed letters must be near-adjacent (up to 1 char between)\n", mark(scorer.FuzzyTight))
+	fmt.Printf("            e.g. `gco` → `gco`, `g.co`, `gc.o`\n\n")
+	fmt.Println("change with:  deja fuzzy <loose|smart|tight>")
+	fmt.Println("set in shell: export DEJA_FUZZY=smart")
+}
+
+func dialGetConfig() (daemon.GetConfigResp, error) {
+	sock, err := sockPath()
+	if err != nil {
+		return daemon.GetConfigResp{}, err
+	}
+	conn, err := net.DialTimeout("unix", sock, dialTimeout)
+	if err != nil {
+		return daemon.GetConfigResp{}, err
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(readTimeout))
+
+	if err := json.NewEncoder(conn).Encode(daemon.Envelope{Type: "getconfig"}); err != nil {
+		return daemon.GetConfigResp{}, err
+	}
+	var resp daemon.GetConfigResp
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		return daemon.GetConfigResp{}, err
+	}
+	return resp, nil
+}
+
+func dialSetConfig(req daemon.SetConfigReq) (daemon.SetConfigResp, error) {
+	sock, err := sockPath()
+	if err != nil {
+		return daemon.SetConfigResp{}, err
+	}
+	conn, err := net.DialTimeout("unix", sock, dialTimeout)
+	if err != nil {
+		return daemon.SetConfigResp{}, err
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(readTimeout))
+
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return daemon.SetConfigResp{}, err
+	}
+	if err := json.NewEncoder(conn).Encode(daemon.Envelope{Type: "setconfig", Payload: payload}); err != nil {
+		return daemon.SetConfigResp{}, err
+	}
+	var resp daemon.SetConfigResp
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		return daemon.SetConfigResp{}, err
+	}
+	if resp.Error != "" {
+		return resp, fmt.Errorf("daemon: %s", resp.Error)
+	}
+	return resp, nil
+}

--- a/cmd/deja/fuzzy.go
+++ b/cmd/deja/fuzzy.go
@@ -24,12 +24,15 @@ func runFuzzy(args []string) {
 		fmt.Fprintln(w, "Usage:")
 		fmt.Fprintln(w, "  deja fuzzy                 show the current preset and examples")
 		fmt.Fprintln(w, "  deja fuzzy <preset>        set the preset (loose|smart|tight)")
+		fmt.Fprintln(w, "  deja fuzzy cycle           advance to the next preset (tight→smart→loose→tight)")
+		fmt.Fprintln(w, "  deja fuzzy back            step to the previous preset (loose→smart→tight→loose)")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "The preset controls how far apart typed letters may be in a candidate")
 		fmt.Fprintln(w, "command. Changes take effect immediately if the daemon is running, and")
 		fmt.Fprintln(w, "are persisted to ~/.local/share/deja/config so they survive restarts.")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "Override at session level with: export DEJA_FUZZY=smart")
+		fmt.Fprintln(w, "In zsh, press Shift+→ / Shift+← to cycle forward / backward without typing.")
 	}
 	parseFlags(fs, args)
 
@@ -39,7 +42,14 @@ func runFuzzy(args []string) {
 		current := readCurrentFuzzy()
 		printFuzzyHelp(current, nil)
 	case 1:
-		setFuzzy(rest[0])
+		switch strings.ToLower(strings.TrimSpace(rest[0])) {
+		case "cycle":
+			cycleFuzzy()
+		case "back":
+			backFuzzy()
+		default:
+			setFuzzy(rest[0])
+		}
 	default:
 		fmt.Fprintln(os.Stderr, "deja fuzzy: too many arguments")
 		printFuzzyHelp(readCurrentFuzzy(), nil)
@@ -63,6 +73,27 @@ func readCurrentFuzzy() scorer.Fuzzy {
 	return f
 }
 
+// applyFuzzy persists f to the config file and pushes it to the running
+// daemon (if reachable). prev is the **file-persisted** previous value; it
+// reflects what the file said before the write, not the env-resolved
+// effective value, so callers can print an accurate diff.
+func applyFuzzy(f scorer.Fuzzy) (prev scorer.Fuzzy, hadFile, daemonApplied bool, err error) {
+	dir, derr := dataDir()
+	if derr != nil {
+		return scorer.FuzzyDefault, false, false, derr
+	}
+	prev, hadFile = config.LoadFuzzyFile(dir)
+
+	if err := config.SaveFuzzy(dir, f); err != nil {
+		return prev, hadFile, false, fmt.Errorf("persist: %w", err)
+	}
+
+	if _, derr := dialSetConfig(daemon.SetConfigReq{Fuzzy: f.String()}); derr == nil {
+		daemonApplied = true
+	}
+	return prev, hadFile, daemonApplied, nil
+}
+
 func setFuzzy(raw string) {
 	f, err := scorer.ParseFuzzy(raw)
 	if err != nil {
@@ -71,26 +102,18 @@ func setFuzzy(raw string) {
 		os.Exit(2)
 	}
 
-	dir, err := dataDir()
+	prev, hadFile, daemonApplied, err := applyFuzzy(f)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "deja fuzzy: %v\n", err)
 		os.Exit(1)
 	}
-	prev, _ := config.LoadFuzzy(dir)
 
-	if err := config.SaveFuzzy(dir, f); err != nil {
-		fmt.Fprintf(os.Stderr, "deja fuzzy: persist: %v\n", err)
-		os.Exit(1)
-	}
-
-	daemonApplied := false
-	if _, derr := dialSetConfig(daemon.SetConfigReq{Fuzzy: f.String()}); derr == nil {
-		daemonApplied = true
-	}
-
-	if prev == f {
+	switch {
+	case !hadFile:
+		fmt.Printf("fuzzy: (unset) → %s\n", f)
+	case prev == f:
 		fmt.Printf("fuzzy: %s (unchanged)\n", f)
-	} else {
+	default:
 		fmt.Printf("fuzzy: %s → %s\n", prev, f)
 	}
 	if !daemonApplied {
@@ -99,6 +122,27 @@ func setFuzzy(raw string) {
 	if env := strings.TrimSpace(os.Getenv(config.EnvFuzzy)); env != "" && env != f.String() {
 		fmt.Printf("note: DEJA_FUZZY=%s is set in your environment and will override on next daemon start\n", env)
 	}
+}
+
+// cycleFuzzy advances to the next preset (tight→smart→loose→tight) and
+// prints just the new preset name to stdout. The zsh keybinding consumes
+// that single token directly; humans use `deja fuzzy <preset>` for prose.
+func cycleFuzzy() {
+	stepFuzzy(scorer.NextFuzzy)
+}
+
+// backFuzzy is the inverse of cycleFuzzy (loose→smart→tight→loose).
+func backFuzzy() {
+	stepFuzzy(scorer.PrevFuzzy)
+}
+
+func stepFuzzy(step func(scorer.Fuzzy) scorer.Fuzzy) {
+	next := step(readCurrentFuzzy())
+	if _, _, _, err := applyFuzzy(next); err != nil {
+		fmt.Fprintf(os.Stderr, "deja fuzzy: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(next)
 }
 
 func printFuzzyHelp(current scorer.Fuzzy, _ error) {
@@ -116,6 +160,8 @@ func printFuzzyHelp(current scorer.Fuzzy, _ error) {
 	fmt.Printf("  %s tight   typed letters must be near-adjacent (up to 1 char between)\n", mark(scorer.FuzzyTight))
 	fmt.Printf("            e.g. `gco` → `gco`, `g.co`, `gc.o`\n\n")
 	fmt.Println("change with:  deja fuzzy <loose|smart|tight>")
+	fmt.Println("cycle next:   deja fuzzy cycle    (or press Shift+→ in zsh)")
+	fmt.Println("cycle prev:   deja fuzzy back     (or press Shift+← in zsh)")
 	fmt.Println("set in shell: export DEJA_FUZZY=smart")
 }
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -32,6 +32,8 @@ func main() {
 		runRecord(args)
 	case "ping":
 		runPing(args)
+	case "fuzzy":
+		runFuzzy(args)
 	case "version", "-v", "--version":
 		printVersion()
 	case "-h", "--help", "help":
@@ -57,5 +59,6 @@ subcommands:
   init     print shell integration script
   record   record an executed command (used by shell hooks)
   ping     check if the daemon is running
+  fuzzy    show or change the fuzzy strictness preset
   version  print the version, commit, and build date`)
 }

--- a/cmd/deja/query.go
+++ b/cmd/deja/query.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/giammarcoferranti/deja/internal/config"
 	"github.com/giammarcoferranti/deja/internal/daemon"
 	"github.com/giammarcoferranti/deja/internal/scorer"
 	"github.com/giammarcoferranti/deja/internal/store"
@@ -129,7 +130,11 @@ func fallbackSuggest(buffer, dir, prev string) daemon.SuggestResp {
 		dirCounts[s.Command] = dc
 	}
 
-	ranked := scorer.Rank(stats, buffer, dir, prev, seq, dirCounts, time.Now())
+	fuzziness := scorer.FuzzyDefault
+	if cfgDir, err := dataDir(); err == nil {
+		fuzziness, _ = config.LoadFuzzy(cfgDir)
+	}
+	ranked := scorer.Rank(stats, buffer, dir, prev, seq, dirCounts, time.Now(), fuzziness)
 	if len(ranked) == 0 {
 		return daemon.SuggestResp{}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,21 @@ func LoadFuzzy(dir string) (scorer.Fuzzy, Source) {
 	return scorer.FuzzyDefault, SourceDefault
 }
 
+// LoadFuzzyFile reads only the persisted fuzzy preset, ignoring DEJA_FUZZY.
+// The second return is false when no valid file value is present.
+//
+// Use this when you need to diff the user's *persisted* state (e.g. to print
+// "fuzzy: tight → smart"); LoadFuzzy resolves env-first and so reports the
+// effective value, which lies about what the file change did.
+func LoadFuzzyFile(dir string) (scorer.Fuzzy, bool) {
+	if v, ok := readKey(dir, fuzzyKey); ok {
+		if f, err := scorer.ParseFuzzy(v); err == nil {
+			return f, true
+		}
+	}
+	return scorer.FuzzyDefault, false
+}
+
 // SaveFuzzy atomically persists the fuzzy preset to the config file in dir.
 func SaveFuzzy(dir string, f scorer.Fuzzy) error {
 	return writeKey(dir, fuzzyKey, f.String())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,119 @@
+// Package config persists user-tunable settings (currently just the fuzzy
+// strictness preset) in a tiny key=value file. The daemon reads it once at
+// startup; the `deja fuzzy` CLI writes to it when the user changes the preset.
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/giammarcoferranti/deja/internal/scorer"
+)
+
+const (
+	fileName = "config"
+	fuzzyKey = "fuzzy"
+
+	// EnvFuzzy is the environment variable that overrides the persisted
+	// fuzzy preset at daemon startup.
+	EnvFuzzy = "DEJA_FUZZY"
+)
+
+// Source indicates where a resolved value came from.
+type Source int
+
+const (
+	SourceDefault Source = iota
+	SourceFile
+	SourceEnv
+)
+
+// LoadFuzzy resolves the fuzzy preset by checking DEJA_FUZZY first, then the
+// persisted config file in dir, then falling back to FuzzyDefault. The second
+// return value identifies which source supplied the value.
+func LoadFuzzy(dir string) (scorer.Fuzzy, Source) {
+	if v := strings.TrimSpace(os.Getenv(EnvFuzzy)); v != "" {
+		if f, err := scorer.ParseFuzzy(v); err == nil {
+			return f, SourceEnv
+		}
+	}
+	if v, ok := readKey(dir, fuzzyKey); ok {
+		if f, err := scorer.ParseFuzzy(v); err == nil {
+			return f, SourceFile
+		}
+	}
+	return scorer.FuzzyDefault, SourceDefault
+}
+
+// SaveFuzzy atomically persists the fuzzy preset to the config file in dir.
+func SaveFuzzy(dir string, f scorer.Fuzzy) error {
+	return writeKey(dir, fuzzyKey, f.String())
+}
+
+func readKey(dir, key string) (string, bool) {
+	if dir == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(filepath.Join(dir, fileName))
+	if err != nil {
+		return "", false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(k) != key {
+			continue
+		}
+		return strings.TrimSpace(v), true
+	}
+	return "", false
+}
+
+func writeKey(dir, key, value string) error {
+	if dir == "" {
+		return errors.New("config dir is empty")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, fileName)
+
+	var lines []string
+	if data, err := os.ReadFile(path); err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			if k, _, ok := strings.Cut(trimmed, "="); ok && strings.TrimSpace(k) == key {
+				continue
+			}
+			lines = append(lines, line)
+		}
+	}
+	lines = append(lines, key+"="+value)
+	out := strings.Join(lines, "\n") + "\n"
+
+	tmp, err := os.CreateTemp(dir, fileName+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.WriteString(out); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,29 @@ func TestLoadFuzzy_InvalidEnvFallsThrough(t *testing.T) {
 	}
 }
 
+func TestLoadFuzzyFile_IgnoresEnv(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveFuzzy(dir, scorer.FuzzyTight); err != nil {
+		t.Fatalf("SaveFuzzy: %v", err)
+	}
+	t.Setenv(EnvFuzzy, "loose")
+
+	got, hadFile := LoadFuzzyFile(dir)
+	if !hadFile || got != scorer.FuzzyTight {
+		t.Errorf("LoadFuzzyFile(env=loose, file=tight) = (%v, %v), want (tight, true)", got, hadFile)
+	}
+}
+
+func TestLoadFuzzyFile_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(EnvFuzzy, "tight")
+
+	got, hadFile := LoadFuzzyFile(dir)
+	if hadFile || got != scorer.FuzzyDefault {
+		t.Errorf("LoadFuzzyFile(no file) = (%v, %v), want (default, false)", got, hadFile)
+	}
+}
+
 func TestSaveFuzzy_OverwritesPreviousValue(t *testing.T) {
 	t.Setenv(EnvFuzzy, "")
 	dir := t.TempDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/giammarcoferranti/deja/internal/scorer"
+)
+
+func TestLoadFuzzy_DefaultWhenEmpty(t *testing.T) {
+	t.Setenv(EnvFuzzy, "")
+	dir := t.TempDir()
+
+	got, src := LoadFuzzy(dir)
+	if got != scorer.FuzzyDefault || src != SourceDefault {
+		t.Errorf("LoadFuzzy(empty) = (%v, %v), want (%v, %v)", got, src, scorer.FuzzyDefault, SourceDefault)
+	}
+}
+
+func TestLoadFuzzy_FromFile(t *testing.T) {
+	t.Setenv(EnvFuzzy, "")
+	dir := t.TempDir()
+
+	if err := SaveFuzzy(dir, scorer.FuzzyTight); err != nil {
+		t.Fatalf("SaveFuzzy: %v", err)
+	}
+
+	got, src := LoadFuzzy(dir)
+	if got != scorer.FuzzyTight || src != SourceFile {
+		t.Errorf("LoadFuzzy(file=tight) = (%v, %v), want (%v, %v)", got, src, scorer.FuzzyTight, SourceFile)
+	}
+}
+
+func TestLoadFuzzy_EnvOverridesFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveFuzzy(dir, scorer.FuzzyTight); err != nil {
+		t.Fatalf("SaveFuzzy: %v", err)
+	}
+	t.Setenv(EnvFuzzy, "loose")
+
+	got, src := LoadFuzzy(dir)
+	if got != scorer.FuzzyLoose || src != SourceEnv {
+		t.Errorf("LoadFuzzy(env=loose, file=tight) = (%v, %v), want (%v, %v)", got, src, scorer.FuzzyLoose, SourceEnv)
+	}
+}
+
+func TestLoadFuzzy_InvalidEnvFallsThrough(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveFuzzy(dir, scorer.FuzzyTight); err != nil {
+		t.Fatalf("SaveFuzzy: %v", err)
+	}
+	t.Setenv(EnvFuzzy, "bananas")
+
+	got, src := LoadFuzzy(dir)
+	if got != scorer.FuzzyTight || src != SourceFile {
+		t.Errorf("LoadFuzzy(env=invalid) should fall through to file, got (%v, %v)", got, src)
+	}
+}
+
+func TestSaveFuzzy_OverwritesPreviousValue(t *testing.T) {
+	t.Setenv(EnvFuzzy, "")
+	dir := t.TempDir()
+
+	if err := SaveFuzzy(dir, scorer.FuzzyTight); err != nil {
+		t.Fatalf("SaveFuzzy tight: %v", err)
+	}
+	if err := SaveFuzzy(dir, scorer.FuzzyLoose); err != nil {
+		t.Fatalf("SaveFuzzy loose: %v", err)
+	}
+
+	got, _ := LoadFuzzy(dir)
+	if got != scorer.FuzzyLoose {
+		t.Errorf("after overwrite want loose, got %v", got)
+	}
+}
+
+func TestSaveFuzzy_PreservesUnrelatedLines(t *testing.T) {
+	t.Setenv(EnvFuzzy, "")
+	dir := t.TempDir()
+	cfg := dir + "/config"
+
+	if err := os.WriteFile(cfg, []byte("# header comment\nunrelated=value\nfuzzy=loose\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := SaveFuzzy(dir, scorer.FuzzyTight); err != nil {
+		t.Fatalf("SaveFuzzy: %v", err)
+	}
+
+	data, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(data)
+	if !contains(s, "unrelated=value") {
+		t.Errorf("unrelated line dropped: %q", s)
+	}
+	if !contains(s, "fuzzy=tight") {
+		t.Errorf("fuzzy not updated to tight: %q", s)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -22,7 +22,7 @@ func (s *State) Suggest(req SuggestReq, now time.Time) SuggestResp {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	ranked := scorer.Rank(s.stats, req.Buffer, req.Dir, req.Prev, seq, s.dirCounts, now)
+	ranked := scorer.Rank(s.stats, req.Buffer, req.Dir, req.Prev, seq, s.dirCounts, now, s.fuzzy)
 	if len(ranked) == 0 {
 		return SuggestResp{}
 	}
@@ -108,4 +108,22 @@ func (s *State) Record(req RecordReq) error {
 // to decide whether to spawn a new daemon.
 func (s *State) Ping() PingResp {
 	return PingResp{Pong: true}
+}
+
+// SetConfig applies runtime settings sent by the CLI. Invalid values are
+// rejected and the previous setting is preserved.
+func (s *State) SetConfig(req SetConfigReq) SetConfigResp {
+	if req.Fuzzy != "" {
+		f, err := scorer.ParseFuzzy(req.Fuzzy)
+		if err != nil {
+			return SetConfigResp{Fuzzy: s.GetFuzzy().String(), Error: err.Error()}
+		}
+		s.SetFuzzy(f)
+	}
+	return SetConfigResp{Fuzzy: s.GetFuzzy().String()}
+}
+
+// GetConfig returns the current runtime settings.
+func (s *State) GetConfig() GetConfigResp {
+	return GetConfigResp{Fuzzy: s.GetFuzzy().String()}
 }

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -3,7 +3,8 @@ package daemon
 import "encoding/json"
 
 // Envelope is the outer shape of every socket message. The payload is
-// interpreted based on Type — one of: "suggest", "record", "ping".
+// interpreted based on Type — one of: "suggest", "record", "ping",
+// "setconfig", "getconfig".
 type Envelope struct {
 	Type    string          `json:"type"`
 	Payload json.RawMessage `json:"payload,omitempty"`
@@ -33,4 +34,22 @@ type RecordResp struct{}
 
 type PingResp struct {
 	Pong bool `json:"pong"`
+}
+
+// SetConfigReq mutates daemon-side settings. Empty fields mean "leave alone".
+type SetConfigReq struct {
+	Fuzzy string `json:"fuzzy,omitempty"`
+}
+
+// SetConfigResp echoes the resulting effective settings. Error is non-empty
+// when the request was rejected (invalid value); the previous setting is kept.
+type SetConfigResp struct {
+	Fuzzy string `json:"fuzzy"`
+	Error string `json:"error,omitempty"`
+}
+
+type GetConfigReq struct{}
+
+type GetConfigResp struct {
+	Fuzzy string `json:"fuzzy"`
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -123,5 +123,15 @@ func handle(conn net.Conn, state *State) {
 
 	case "ping":
 		_ = enc.Encode(state.Ping())
+
+	case "setconfig":
+		var req SetConfigReq
+		if err := json.Unmarshal(env.Payload, &req); err != nil {
+			return
+		}
+		_ = enc.Encode(state.SetConfig(req))
+
+	case "getconfig":
+		_ = enc.Encode(state.GetConfig())
 	}
 }

--- a/internal/daemon/state.go
+++ b/internal/daemon/state.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"sync"
 
+	"github.com/giammarcoferranti/deja/internal/scorer"
 	"github.com/giammarcoferranti/deja/internal/store"
 	"gorm.io/gorm"
 )
@@ -15,6 +16,7 @@ type State struct {
 	stats     []store.CommandStat       // top-100 most-used, from GetCommandStats
 	seqByPrev map[string]map[string]int // prev → next → count, filled lazily
 	dirCounts map[string]map[string]int // cmd  → dir  → count
+	fuzzy     scorer.Fuzzy              // strictness preset for fuzzy matching
 }
 
 // Load warms state from SQLite. It preloads only the dirCounts for the
@@ -39,7 +41,22 @@ func Load(db *gorm.DB) (*State, error) {
 		stats:     stats,
 		seqByPrev: make(map[string]map[string]int),
 		dirCounts: dirCounts,
+		fuzzy:     scorer.FuzzyDefault,
 	}, nil
+}
+
+// SetFuzzy updates the strictness preset used by Suggest.
+func (s *State) SetFuzzy(f scorer.Fuzzy) {
+	s.mu.Lock()
+	s.fuzzy = f
+	s.mu.Unlock()
+}
+
+// GetFuzzy returns the current strictness preset.
+func (s *State) GetFuzzy() scorer.Fuzzy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.fuzzy
 }
 
 // SeqCounts returns the cached next-command counts for a given prev,

--- a/internal/scorer/scorer.go
+++ b/internal/scorer/scorer.go
@@ -1,8 +1,10 @@
 package scorer
 
 import (
+	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/giammarcoferranti/deja/internal/store"
@@ -12,6 +14,62 @@ import (
 type Result struct {
 	Command string
 	Score   float64
+}
+
+// Fuzzy is the strictness preset that controls how far apart typed letters may
+// be in a candidate command. Smaller gaps = tighter matches.
+type Fuzzy int
+
+const (
+	FuzzyLoose Fuzzy = iota
+	FuzzySmart
+	FuzzyTight
+)
+
+// FuzzyDefault is the preset used when nothing else is configured.
+const FuzzyDefault = FuzzySmart
+
+func (f Fuzzy) String() string {
+	switch f {
+	case FuzzyLoose:
+		return "loose"
+	case FuzzyTight:
+		return "tight"
+	default:
+		return "smart"
+	}
+}
+
+// ParseFuzzy turns a user-supplied preset name into a Fuzzy value.
+// Empty input is treated as the default.
+func ParseFuzzy(s string) (Fuzzy, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return FuzzyDefault, nil
+	case "loose":
+		return FuzzyLoose, nil
+	case "smart":
+		return FuzzySmart, nil
+	case "tight":
+		return FuzzyTight, nil
+	default:
+		return FuzzyDefault, fmt.Errorf("unknown fuzzy preset %q (want loose|smart|tight)", s)
+	}
+}
+
+// maxGap returns the maximum number of unmatched characters allowed between
+// two consecutive typed letters in a candidate. Values are tuned so `smart`
+// handles canonical shell fuzzy cases (`gco` → `git checkout`, gap 4) and
+// `tight` requires near-adjacency.
+func maxGap(f Fuzzy) int {
+	switch f {
+	case FuzzyLoose:
+		return 8
+	case FuzzyTight:
+		return 1
+	default:
+		return 4
+	}
 }
 
 const halfLife = 7 * 24 * time.Hour
@@ -27,13 +85,14 @@ func Rank(
 	seqCounts map[string]int,
 	dirCounts map[string]map[string]int,
 	now time.Time,
+	fuzziness Fuzzy,
 ) []Result {
 	n := len(candidates)
 	if n == 0 {
 		return nil
 	}
 
-	fuzzyScores := computeFuzzy(candidates, buffer)
+	fuzzyScores := computeFuzzy(candidates, buffer, fuzziness)
 	frecencyScores := computeFrecency(candidates, now)
 	dirScores := computeDirAffinity(candidates, dir, dirCounts)
 	seqScores := computeSequence(candidates, seqCounts)
@@ -57,7 +116,7 @@ func Rank(
 
 }
 
-func computeFuzzy(candidates []store.CommandStat, buffer string) []float64 {
+func computeFuzzy(candidates []store.CommandStat, buffer string, fuzziness Fuzzy) []float64 {
 	scores := make([]float64, len(candidates))
 
 	if buffer == "" {
@@ -77,18 +136,37 @@ func computeFuzzy(candidates []store.CommandStat, buffer string) []float64 {
 		return scores
 	}
 
+	// Drop matches whose typed letters are spread further apart than the
+	// configured preset allows. Single-character buffers have no gap to
+	// measure, so they bypass the filter.
+	gapCap := maxGap(fuzziness)
+	filterByGap := len(buffer) > 1
+
 	matched := make([]bool, len(candidates))
 	raw := make([]int, len(candidates))
-	min, max := matches[0].Score, matches[0].Score
+	first := true
+	var min, max int
 	for _, m := range matches {
+		if filterByGap && maxConsecutiveGap(m.MatchedIndexes) > gapCap {
+			continue
+		}
 		raw[m.Index] = m.Score
 		matched[m.Index] = true
+		if first {
+			min, max = m.Score, m.Score
+			first = false
+			continue
+		}
 		if m.Score < min {
 			min = m.Score
 		}
 		if m.Score > max {
 			max = m.Score
 		}
+	}
+	if first {
+		// Every match was filtered out by the gap cap.
+		return scores
 	}
 
 	span := max - min
@@ -186,4 +264,20 @@ func computeSequence(candidates []store.CommandStat, seqCounts map[string]int) [
 	}
 
 	return scores
+}
+
+// maxConsecutiveGap returns the largest run of unmatched characters between
+// consecutive matched positions. Returns 0 when fewer than two matches exist.
+func maxConsecutiveGap(indexes []int) int {
+	if len(indexes) < 2 {
+		return 0
+	}
+	worst := 0
+	for i := 1; i < len(indexes); i++ {
+		gap := indexes[i] - indexes[i-1] - 1
+		if gap > worst {
+			worst = gap
+		}
+	}
+	return worst
 }

--- a/internal/scorer/scorer.go
+++ b/internal/scorer/scorer.go
@@ -40,6 +40,37 @@ func (f Fuzzy) String() string {
 	}
 }
 
+// NextFuzzy returns the next preset in the strictness ramp:
+// tight → smart → loose → tight. Used by `deja fuzzy cycle` and the
+// Shift+→ zsh keybinding to step through presets without typing a name.
+func NextFuzzy(f Fuzzy) Fuzzy {
+	switch f {
+	case FuzzyTight:
+		return FuzzySmart
+	case FuzzySmart:
+		return FuzzyLoose
+	case FuzzyLoose:
+		return FuzzyTight
+	default:
+		return FuzzyDefault
+	}
+}
+
+// PrevFuzzy is the inverse of NextFuzzy: loose → smart → tight → loose.
+// Used by `deja fuzzy back` and the Shift+← keybinding.
+func PrevFuzzy(f Fuzzy) Fuzzy {
+	switch f {
+	case FuzzyLoose:
+		return FuzzySmart
+	case FuzzySmart:
+		return FuzzyTight
+	case FuzzyTight:
+		return FuzzyLoose
+	default:
+		return FuzzyDefault
+	}
+}
+
 // ParseFuzzy turns a user-supplied preset name into a Fuzzy value.
 // Empty input is treated as the default.
 func ParseFuzzy(s string) (Fuzzy, error) {

--- a/internal/scorer/scorer_test.go
+++ b/internal/scorer/scorer_test.go
@@ -21,7 +21,7 @@ func TestRank(t *testing.T) {
 		"git commit -m": {"/repo": 45, "/other": 5},
 	}
 
-	got := Rank(candidates, "gi", "/repo", "git add .", seqCounts, dirCounts, now)
+	got := Rank(candidates, "gi", "/repo", "git add .", seqCounts, dirCounts, now, FuzzyLoose)
 
 	// "go test ./..." has no 'i' after 'g', fuzzy filters it out.
 	for _, r := range got {
@@ -55,7 +55,7 @@ func TestRank_ExactScores(t *testing.T) {
 
 	// Empty buffer: fuzzy = 1 for every candidate, so final score equals
 	// 1.0 + weighted non-fuzzy signals. Makes implied-fuzzy checks tight.
-	got := Rank(candidates, "", "/repo", "git add .", seqCounts, dirCounts, now)
+	got := Rank(candidates, "", "/repo", "git add .", seqCounts, dirCounts, now, FuzzyLoose)
 
 	if len(got) != 3 {
 		t.Fatalf("expected 3 results, got %d: %+v", len(got), got)
@@ -104,7 +104,7 @@ func TestRank_EdgeCases(t *testing.T) {
 	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
 
 	t.Run("empty candidates returns nil", func(t *testing.T) {
-		got := Rank(nil, "git", "/repo", "", nil, nil, now)
+		got := Rank(nil, "git", "/repo", "", nil, nil, now, FuzzyLoose)
 		if got != nil {
 			t.Errorf("want nil, got %+v", got)
 		}
@@ -115,7 +115,7 @@ func TestRank_EdgeCases(t *testing.T) {
 			{Command: "git status", Count: 1, LastUsed: now},
 			{Command: "make build", Count: 1, LastUsed: now},
 		}
-		got := Rank(candidates, "zzzz", "/repo", "", nil, nil, now)
+		got := Rank(candidates, "zzzz", "/repo", "", nil, nil, now, FuzzyLoose)
 		if len(got) != 0 {
 			t.Errorf("want empty results, got %+v", got)
 		}
@@ -126,7 +126,7 @@ func TestRank_EdgeCases(t *testing.T) {
 			{Command: "git status", Count: 0, LastUsed: now},
 			{Command: "git commit", Count: 0, LastUsed: now},
 		}
-		got := Rank(candidates, "", "/repo", "", map[string]int{}, map[string]map[string]int{}, now)
+		got := Rank(candidates, "", "/repo", "", map[string]int{}, map[string]map[string]int{}, now, FuzzyLoose)
 		if len(got) != 2 {
 			t.Fatalf("want 2 results, got %+v", got)
 		}
@@ -141,7 +141,7 @@ func TestRank_EdgeCases(t *testing.T) {
 		candidates := []store.CommandStat{
 			{Command: "git status", Count: 1, LastUsed: now},
 		}
-		got := Rank(candidates, "git", "", "", nil, nil, now)
+		got := Rank(candidates, "git", "", "", nil, nil, now, FuzzyLoose)
 		if len(got) != 1 {
 			t.Fatalf("want 1 result, got %+v", got)
 		}
@@ -160,7 +160,7 @@ func TestRank_EdgeCases(t *testing.T) {
 			{Command: "future-cmd", Count: 5, LastUsed: future},
 			{Command: "past-cmd", Count: 5, LastUsed: past},
 		}
-		got := Rank(candidates, "", "", "", nil, nil, now)
+		got := Rank(candidates, "", "", "", nil, nil, now, FuzzyLoose)
 		if len(got) != 2 {
 			t.Fatalf("want 2 results, got %+v", got)
 		}
@@ -185,8 +185,8 @@ func TestRank_EdgeCases(t *testing.T) {
 		}
 		// dir="" — computeDirAffinity should return zeros, so the dir signal
 		// contributes nothing. Compare against a run with a matching dir.
-		gotEmptyDir := Rank(candidates, "", "", "", nil, dirCounts, now)
-		gotMatchedDir := Rank(candidates, "", "/repo", "", nil, dirCounts, now)
+		gotEmptyDir := Rank(candidates, "", "", "", nil, dirCounts, now, FuzzyLoose)
+		gotMatchedDir := Rank(candidates, "", "/repo", "", nil, dirCounts, now, FuzzyLoose)
 
 		if len(gotEmptyDir) != 1 || len(gotMatchedDir) != 1 {
 			t.Fatalf("want 1 result each, got %+v / %+v", gotEmptyDir, gotMatchedDir)
@@ -201,7 +201,7 @@ func TestRank_EdgeCases(t *testing.T) {
 		candidates := []store.CommandStat{
 			{Command: "git status", Count: 1, LastUsed: now},
 		}
-		got := Rank(candidates, "", "", "no-such-prev", map[string]int{}, nil, now)
+		got := Rank(candidates, "", "", "no-such-prev", map[string]int{}, nil, now, FuzzyLoose)
 		if len(got) != 1 {
 			t.Fatalf("want 1 result, got %+v", got)
 		}
@@ -218,7 +218,7 @@ func TestRank_EdgeCases(t *testing.T) {
 			{Command: "git status", Count: 1 << 30, LastUsed: now},
 			{Command: "git commit", Count: 1 << 28, LastUsed: now},
 		}
-		got := Rank(candidates, "", "", "", nil, nil, now)
+		got := Rank(candidates, "", "", "", nil, nil, now, FuzzyLoose)
 		if len(got) != 2 {
 			t.Fatalf("want 2 results, got %+v", got)
 		}
@@ -226,6 +226,125 @@ func TestRank_EdgeCases(t *testing.T) {
 			if math.IsNaN(r.Score) || math.IsInf(r.Score, 0) {
 				t.Errorf("score for %q is not finite: %v", r.Command, r.Score)
 			}
+		}
+	})
+}
+
+func TestParseFuzzy(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    Fuzzy
+		wantErr bool
+	}{
+		{"loose", FuzzyLoose, false},
+		{"smart", FuzzySmart, false},
+		{"tight", FuzzyTight, false},
+		{"  Smart  ", FuzzySmart, false},
+		{"TIGHT", FuzzyTight, false},
+		{"", FuzzyDefault, false},
+		{"medium", FuzzyDefault, true},
+	}
+	for _, tc := range tests {
+		got, err := ParseFuzzy(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ParseFuzzy(%q) err=%v wantErr=%v", tc.in, err, tc.wantErr)
+		}
+		if got != tc.want {
+			t.Errorf("ParseFuzzy(%q) = %v want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFuzzy_String(t *testing.T) {
+	for _, tc := range []struct {
+		f    Fuzzy
+		want string
+	}{
+		{FuzzyLoose, "loose"},
+		{FuzzySmart, "smart"},
+		{FuzzyTight, "tight"},
+	} {
+		if got := tc.f.String(); got != tc.want {
+			t.Errorf("Fuzzy(%d).String() = %q want %q", tc.f, got, tc.want)
+		}
+	}
+}
+
+func TestRank_GapFilter(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+
+	candidates := []store.CommandStat{
+		// gco gap pattern in each (smart cap=4, loose cap=8, tight cap=1):
+		{Command: "gco"},                     // gaps: 0, 0     — all presets pass
+		{Command: "g.co"},                    // gaps: 1, 0     — all presets pass
+		{Command: "git co main"},             // g(0),c(4),o(5) — gaps: 3, 0 — smart + loose
+		{Command: "git checkout main"},       // g(0),c(4),o(9) — gaps: 3, 4 — smart + loose
+		{Command: "g.....c.....o"},           // g(0),c(6),o(12)— gaps: 5, 5 — loose only
+		{Command: "g........c........o"},     // gaps: 8, 8     — loose only, at the edge
+		{Command: "g..........c..........o"}, // gaps: 10, 10   — none pass
+	}
+
+	hasCmd := func(rs []Result, cmd string) bool {
+		for _, r := range rs {
+			if r.Command == cmd {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("tight only keeps gap<=1", func(t *testing.T) {
+		got := Rank(candidates, "gco", "", "", nil, nil, now, FuzzyTight)
+		if !hasCmd(got, "gco") || !hasCmd(got, "g.co") {
+			t.Errorf("tight: expected gco and g.co, got %+v", got)
+		}
+		for _, bad := range []string{"git co main", "git checkout main", "g.....c.....o"} {
+			if hasCmd(got, bad) {
+				t.Errorf("tight: did not expect %q in results, got %+v", bad, got)
+			}
+		}
+	})
+
+	t.Run("smart keeps gap<=4 (canonical gco→git checkout works)", func(t *testing.T) {
+		got := Rank(candidates, "gco", "", "", nil, nil, now, FuzzySmart)
+		for _, want := range []string{"gco", "g.co", "git co main", "git checkout main"} {
+			if !hasCmd(got, want) {
+				t.Errorf("smart: expected %q in results, got %+v", want, got)
+			}
+		}
+		for _, bad := range []string{"g.....c.....o", "g........c........o", "g..........c..........o"} {
+			if hasCmd(got, bad) {
+				t.Errorf("smart: did not expect %q in results, got %+v", bad, got)
+			}
+		}
+	})
+
+	t.Run("loose keeps gap<=8", func(t *testing.T) {
+		got := Rank(candidates, "gco", "", "", nil, nil, now, FuzzyLoose)
+		for _, want := range []string{"gco", "g.co", "git checkout main", "g.....c.....o", "g........c........o"} {
+			if !hasCmd(got, want) {
+				t.Errorf("loose: expected %q in results, got %+v", want, got)
+			}
+		}
+		if hasCmd(got, "g..........c..........o") {
+			t.Errorf("loose: did not expect very-wide gap match, got %+v", got)
+		}
+	})
+
+	t.Run("single-char buffer bypasses gap filter", func(t *testing.T) {
+		// One letter has no gap to measure; every match must pass even on tight.
+		got := Rank(candidates, "g", "", "", nil, nil, now, FuzzyTight)
+		if len(got) != len(candidates) {
+			t.Errorf("single-char tight: expected all %d to match, got %d: %+v",
+				len(candidates), len(got), got)
+		}
+	})
+
+	t.Run("empty buffer bypasses gap filter", func(t *testing.T) {
+		got := Rank(candidates, "", "", "", nil, nil, now, FuzzyTight)
+		if len(got) != len(candidates) {
+			t.Errorf("empty tight: expected all %d to match, got %d: %+v",
+				len(candidates), len(got), got)
 		}
 	})
 }

--- a/internal/scorer/scorer_test.go
+++ b/internal/scorer/scorer_test.go
@@ -255,6 +255,47 @@ func TestParseFuzzy(t *testing.T) {
 	}
 }
 
+func TestNextFuzzy(t *testing.T) {
+	for _, tc := range []struct {
+		in, want Fuzzy
+	}{
+		{FuzzyTight, FuzzySmart},
+		{FuzzySmart, FuzzyLoose},
+		{FuzzyLoose, FuzzyTight},
+	} {
+		if got := NextFuzzy(tc.in); got != tc.want {
+			t.Errorf("NextFuzzy(%v) = %v want %v", tc.in, got, tc.want)
+		}
+	}
+
+	// Three rotations land back on the starting preset.
+	start := FuzzyTight
+	if got := NextFuzzy(NextFuzzy(NextFuzzy(start))); got != start {
+		t.Errorf("3x NextFuzzy(%v) = %v want %v", start, got, start)
+	}
+}
+
+func TestPrevFuzzy(t *testing.T) {
+	for _, tc := range []struct {
+		in, want Fuzzy
+	}{
+		{FuzzyLoose, FuzzySmart},
+		{FuzzySmart, FuzzyTight},
+		{FuzzyTight, FuzzyLoose},
+	} {
+		if got := PrevFuzzy(tc.in); got != tc.want {
+			t.Errorf("PrevFuzzy(%v) = %v want %v", tc.in, got, tc.want)
+		}
+	}
+
+	// Prev undoes Next from every starting preset.
+	for _, f := range []Fuzzy{FuzzyTight, FuzzySmart, FuzzyLoose} {
+		if got := PrevFuzzy(NextFuzzy(f)); got != f {
+			t.Errorf("PrevFuzzy(NextFuzzy(%v)) = %v want %v", f, got, f)
+		}
+	}
+}
+
 func TestFuzzy_String(t *testing.T) {
 	for _, tc := range []struct {
 		f    Fuzzy

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -20,6 +20,13 @@ typeset -g DEJA_BIN="{{DEJA_BIN}}"
 # DEJA_FUZZY (unset by default): override the fuzzy strictness preset for the
 # daemon spawned by this shell. One of loose|smart|tight. Use `deja fuzzy` to
 # change the persisted preset instead.
+# DEJA_CYCLE_FUZZY_KEY / DEJA_CYCLE_FUZZY_BACK_KEY: zle key sequences bound to
+# `deja fuzzy cycle` and `deja fuzzy back`. Default to Shift+→ / Shift+←
+# (^[[1;2C / ^[[1;2D in xterm-style terminals). Set either to empty to disable
+# that direction. In tmux you may need `set -g xterm-keys on` for the default
+# Shift+arrow sequences to reach zle.
+: ${DEJA_CYCLE_FUZZY_KEY:='^[[1;2C'}
+: ${DEJA_CYCLE_FUZZY_BACK_KEY:='^[[1;2D'}
 
 typeset -ga DEJA_ACCEPT_WIDGETS
 DEJA_ACCEPT_WIDGETS=(
@@ -69,7 +76,7 @@ DEJA_IGNORE_WIDGETS=(
 )
 
 typeset -ga _DEJA_BUILTIN_ACTIONS
-_DEJA_BUILTIN_ACTIONS=(clear fetch suggest accept execute enable disable toggle cycle)
+_DEJA_BUILTIN_ACTIONS=(clear fetch suggest accept execute enable disable toggle cycle cycle_fuzzy cycle_fuzzy_back)
 
 typeset -g DEJA_SESSION_ID
 if [[ -z "$DEJA_SESSION_ID" ]]; then
@@ -363,6 +370,50 @@ _deja_suggest() {
 
 	_deja_render_suggestion "$suggestion"
 }
+
+# Builds the picker-style status line: "deja: fuzzy   tight   *smart*   loose"
+# with the currently-active preset wrapped in *…*. The order tight→smart→loose
+# mirrors strictness left-to-right so Shift+→ visually moves rightward.
+_deja_fuzzy_picker_line() {
+	local current="$1" p out=""
+	for p in tight smart loose; do
+		if [[ "$p" = "$current" ]]; then
+			out+="  *${p}*"
+		else
+			out+="   ${p} "
+		fi
+	done
+	print -r -- "deja: fuzzy${out}"
+}
+
+# Step the persisted fuzzy preset one direction ($1 = "cycle" or "back") and
+# repaint the ghost suggestion synchronously so the change is visible in the
+# same frame — async would land the new ghost only after the next keystroke,
+# making it feel like the keypress did nothing.
+_deja_step_fuzzy() {
+	[[ -x "$DEJA_BIN" ]] || return 0
+
+	local direction="$1" new
+	new="$("$DEJA_BIN" fuzzy "$direction" 2>/dev/null)"
+	new="${new%$'\n'}"
+	[[ -z "$new" ]] && return 0
+
+	zle -M "$(_deja_fuzzy_picker_line "$new")"
+
+	if (( ${+_DEJA_DISABLED} )); then
+		return 0
+	fi
+
+	# Sync fetch on purpose: async would put the new ghost in place only
+	# after zle returns to its read loop, so the user wouldn't see the
+	# preset change reflected until another keystroke.
+	local suggestion
+	_deja_fetch_suggestion "$BUFFER"
+	_deja_suggest "$suggestion"
+}
+
+_deja_cycle_fuzzy()      { _deja_step_fuzzy cycle; }
+_deja_cycle_fuzzy_back() { _deja_step_fuzzy back; }
 
 _deja_cycle() {
 	local -i n=${#_DEJA_ALTERNATIVES}
@@ -700,9 +751,13 @@ _deja_conflicting_plugin || zle -N zle-line-init _deja_line_init
 # Ctrl+right: partial accept (forward-word is in DEJA_PARTIAL_ACCEPT_WIDGETS).
 # Tab: cycle through alternative suggestions (falls through to expand-or-complete when there are none).
 # Ctrl+X: toggle suppression.
+# Shift+right (DEJA_CYCLE_FUZZY_KEY): cycle the persisted fuzzy preset forward (tight→smart→loose→tight).
+# Shift+left  (DEJA_CYCLE_FUZZY_BACK_KEY): cycle backward (loose→smart→tight→loose).
 _deja_apply_keybindings() {
 	bindkey '^I' deja-cycle
 	bindkey '^X' deja-toggle
+	[[ -n "$DEJA_CYCLE_FUZZY_KEY" ]]      && bindkey "$DEJA_CYCLE_FUZZY_KEY"      deja-cycle_fuzzy
+	[[ -n "$DEJA_CYCLE_FUZZY_BACK_KEY" ]] && bindkey "$DEJA_CYCLE_FUZZY_BACK_KEY" deja-cycle_fuzzy_back
 }
 
 _deja_ensure_daemon

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -17,6 +17,9 @@ typeset -g DEJA_BIN="{{DEJA_BIN}}"
 : ${DEJA_BUFFER_MAX_SIZE:=}
 : ${DEJA_ORIGINAL_WIDGET_PREFIX:=deja-orig-}
 : ${DEJA_FUZZY_SEPARATOR:='  ⊳ '}
+# DEJA_FUZZY (unset by default): override the fuzzy strictness preset for the
+# daemon spawned by this shell. One of loose|smart|tight. Use `deja fuzzy` to
+# change the persisted preset instead.
 
 typeset -ga DEJA_ACCEPT_WIDGETS
 DEJA_ACCEPT_WIDGETS=(


### PR DESCRIPTION
- New fuzzy matching feature: 
 - New 3 subcommands: smart, loose, tight
 - Now the user can define which to use
 - New shortcut to cycle the fuzziness via Shift + right arrow
 - Bindkeys are overridable via export DEJA_CYCLE_FUZZY_KEY, export DEJA_CYCLE_FUZZY_BACK_KEY