### PR TITLE
fix: multiline commands now correclty interpreted

### DIFF
--- a/cmd/deja/query.go
+++ b/cmd/deja/query.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/giammarcoferranti/deja/internal/config"
@@ -61,10 +62,8 @@ func runQuery(args []string) {
 		_ = json.NewEncoder(os.Stdout).Encode(resp)
 	case "lines":
 		if resp.Suggestion != "" {
-			fmt.Println(resp.Suggestion)
-			for _, a := range resp.Alternatives {
-				fmt.Println(a)
-			}
+			cands := append([]string{resp.Suggestion}, resp.Alternatives...)
+			fmt.Print(strings.Join(cands, "\x1f"))
 		}
 	default:
 		if resp.Suggestion != "" {

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -44,22 +44,22 @@ func readHistoryPath() string {
 }
 
 func parseHistoryCommand(history string) []RawCommand {
-	var commands []RawCommand
+	const sentinel = "\x00"
+	folded := strings.ReplaceAll(history, "\\\n", sentinel)
 
-	lines := strings.Split(history, "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
+	var commands []RawCommand
+	for _, entry := range strings.Split(folded, "\n") {
+		entry := strings.ReplaceAll(entry, sentinel, "\n")
+		if strings.TrimSpace(entry) == "" {
 			continue
 		}
-		commands = append(commands, formatCommand(line))
+		commands = append(commands, formatCommand(entry))
 	}
-
 	return commands
 }
 
 func formatCommand(raw string) RawCommand {
-	re := regexp.MustCompile(`^:\s*(\d+):(\d+);(.*)$`)
+	re := regexp.MustCompile(`(?s)^:\s*(\d+):(\d+);(.*)$`)
 	m := re.FindStringSubmatch(raw)
 	if m == nil {
 		return RawCommand{

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -195,6 +195,61 @@ func TestParseHistoryCommand(t *testing.T) {
 			t.Errorf("expected timestamps on entries 0 and 2, none on 1; got %+v", got)
 		}
 	})
+
+	// zsh stores an embedded newline by prepending its own escape backslash, so
+	// a physical line ending in `\` is a continuation of the next line. The real
+	// histfile bytes look like `...config \\<NL>   -type f \\<NL>...` — one
+	// backslash from the user's shell continuation, one added by zsh. The parser
+	// must strip exactly the zsh escape and rejoin with a real `\n` so a single
+	// multiline command stays one entry (with the user's own `\` preserved).
+	t.Run("backslash continuation joins into one multiline command", func(t *testing.T) {
+		input := strings.Join([]string{
+			`: 1700000000:0;find ~/.config \\`,
+			`   -type f \\`,
+			`   -name '*.json'`,
+		}, "\n")
+
+		want := strings.Join([]string{
+			`find ~/.config \`,
+			`   -type f \`,
+			`   -name '*.json'`,
+		}, "\n")
+
+		got := parseHistoryCommand(input)
+		if len(got) != 1 {
+			t.Fatalf("len(got) = %d, want 1: %+v", len(got), got)
+		}
+		if got[0].Command != want {
+			t.Errorf("Command = %q, want %q", got[0].Command, want)
+		}
+		if got[0].Timestamp == nil || got[0].Timestamp.Unix() != 1700000000 {
+			t.Errorf("Timestamp = %v, want unix=1700000000", got[0].Timestamp)
+		}
+	})
+
+	t.Run("multiline entry followed by a normal entry yields two commands", func(t *testing.T) {
+		input := strings.Join([]string{
+			`: 1700000000:0;find ~/.config \\`,
+			`   -type f`,
+			`: 1700000001:0;ls`,
+		}, "\n")
+
+		wantFirst := strings.Join([]string{
+			`find ~/.config \`,
+			`   -type f`,
+		}, "\n")
+
+		got := parseHistoryCommand(input)
+		if len(got) != 2 {
+			t.Fatalf("len(got) = %d, want 2: %+v", len(got), got)
+		}
+		if got[0].Command != wantFirst {
+			t.Errorf("got[0].Command = %q, want %q", got[0].Command, wantFirst)
+		}
+		if got[1].Command != "ls" {
+			t.Errorf("got[1].Command = %q, want %q", got[1].Command, "ls")
+		}
+	})
 }
 
 func ptrInt64(v int64) *int64 { return &v }

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -227,8 +227,6 @@ _deja_async_response() {
 
 	if [[ -z "$2" || "$2" == "hup" ]]; then
 		IFS='' read -rd '' -u $1 suggestion 2>/dev/null
-		# Strip a trailing newline from the `fmt.Println` in query.go.
-		suggestion="${suggestion%$'\n'}"
 		zle deja-suggest -- "$suggestion"
 		# Close only if the fd is still ours — another zle -F user may have
 		# recycled the number. (Never `2>/dev/null` a bare exec: that makes
@@ -363,8 +361,9 @@ _deja_suggest() {
 	local raw="$1"
 
 	# The daemon now emits one candidate per line (--format lines): the
-	# primary suggestion first, then up to 4 alternatives. Split on \n.
-	_DEJA_ALTERNATIVES=("${(@f)raw}")
+	# primary suggestion first, then up to 4 alternatives.
+	local sep=$'\x1f'
+	_DEJA_ALTERNATIVES=("${(@ps:$sep:)raw}")
 	_DEJA_ALT_INDEX=1
 
 	local suggestion="${_DEJA_ALTERNATIVES[1]}"


### PR DESCRIPTION
- Separate candidates with \x1f instead of \n in the query/zsh protocol so a multiline command's ghost text is no longer truncated to its first line
