### PR TITLE
fix: prevent shell breakage from completion widget wrapping and missing binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ git clone https://github.com/Giammarco-Ferranti/deja \
 deja import && exec zsh
 ```
 
+### zinit
+
+If you use [zinit](https://github.com/zdharma-continuum/zinit), add this to your `.zshrc`:
+
+```zsh
+zinit ice wait"0" lucid depth=1
+zinit light Giammarco-Ferranti/deja
+```
+
+zinit handles the Oh My Zsh plugin integration, so the `eval "$(deja init zsh)"` line is not needed. Make sure the `deja` binary is installed separately via Homebrew or the curl installer.
+
+### Manual (any framework)
+
 Prefer not to clone the whole repo? Fetch just the plugin file instead:
 
 ```bash
@@ -78,6 +91,7 @@ mkdir -p ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/deja
 curl -fsSL https://raw.githubusercontent.com/Giammarco-Ferranti/deja/main/deja.plugin.zsh \
   -o ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/deja/deja.plugin.zsh
 ```
+
 
 > **Pick one activation, not both.** The plugin runs `eval "$(deja init zsh)"` for you, so if the installer already appended that line to `~/.zshrc`, remove it. Keeping both double-sources the integration.
 >

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -83,6 +83,7 @@ DEJA_IGNORE_WIDGETS=(
 	yank
 	yank-pop
 	zle-\*
+	expand-or-complete
 )
 
 typeset -ga _DEJA_BUILTIN_ACTIONS
@@ -600,8 +601,7 @@ _deja_bind_widget() {
 			;;
 
 		completion:*)
-			_deja_incr_bind_count $widget
-			eval "zle -C $prefix$bind_count-${(q)widget} ${${(s.:.)widgets[$widget]}[2,3]}"
+			return
 			;;
 	esac
 
@@ -709,7 +709,7 @@ _deja_precmd() {
 	# Keybindings are re-asserted too — frameworks (oh-my-zsh, prezto, etc.)
 	# frequently rebind Tab during their own precmd, and deja's widgets
 	# become unreachable without this.
-	if [[ -z "$DEJA_MANUAL_REBIND" ]] && ! _deja_conflicting_plugin; then
+	if [[ -z "$DEJA_MANUAL_REBIND" ]] && ! _deja_conflicting_plugin && [[ -x "$DEJA_BIN" ]]; then
 		_deja_bind_widgets
 		_deja_apply_keybindings
 	fi
@@ -749,7 +749,9 @@ _deja_line_init() {
 	_deja_widget_fetch
 }
 
-_deja_conflicting_plugin || zle -N zle-line-init _deja_line_init
+if ! _deja_conflicting_plugin && [[ -x "$DEJA_BIN" ]]; then
+	zle -N zle-line-init _deja_line_init
+fi
 
 #--------------------------------------------------------------------#
 # 8. Startup                                                         #
@@ -782,7 +784,7 @@ _deja_ensure_daemon
 # them — that's what wedges the terminal. Warn once and leave the shell alone.
 if _deja_conflicting_plugin; then
 	_deja_warn_conflict
-else
+elif [[ -x "$DEJA_BIN" ]]; then
 	_deja_bind_widgets
 	_deja_apply_keybindings
 fi


### PR DESCRIPTION
## Summary

- Skip completion:* widgets in _deja_bind_widget (zle -N destroys zle -C completion)
- Guard widget wrapping behind [[ -x  ]] checks
- Add expand-or-complete to DEJA_IGNORE_WIDGETS
- Add zinit installation snippet to README

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `BREAKING CHANGE:` footer)
- [ ] Docs / chore / refactor / test / ci

## Test plan

- [x] `go test -race ./...` passes locally
- [x] `go vet ./...` clean
- [ ] Added or updated tests for the change

## Notes for reviewers

I think this might fix #50, #46 and p10k issues.
