### PR TITLE
feat: Add option to suppress suggestions on an empty prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,27 @@ export DEJA_FUZZY=smart   # before the daemon starts; takes precedence over the 
 
 ---
 
+## Suggestions on an empty prompt
+
+By default, on a fresh prompt — before you've typed anything — Deja predicts the command you're most likely to run next, based on command-sequence, frecency, and directory signals, and shows it as ghost text. If you'd rather see nothing until you start typing, turn empty-prompt suggestions off:
+
+```bash
+deja empty            # show whether empty-prompt suggestions are on
+deja empty off        # never suggest on an empty prompt (aliases: deja empty hide)
+deja empty on         # restore the default (aliases: deja empty show)
+deja empty toggle     # flip the current setting
+```
+
+Changes take effect immediately if the daemon is running and persist across restarts (saved to `~/.local/share/deja/config`). Override per shell session with an environment variable:
+
+```bash
+export DEJA_EMPTY=off   # before the daemon starts; takes precedence over the saved setting
+```
+
+This is a **global, persisted** setting. It's different from `Ctrl+X`, which suppresses **all** suggestions for the current shell session only (see [Key Bindings](#key-bindings)).
+
+---
+
 ## Troubleshooting
 
 Every subcommand supports `--help` (e.g. `deja query --help`) for flag-level details. The most common issues:

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Deja auto-spawns its daemon on first use and keeps it running across sessions.
 | `Ctrl+→` | Accept next word only | `DEJA_WORD_ACCEPT_KEY` (extra key) |
 | `Shift+→` | Cycle fuzzy preset forward (tight → smart → loose) | `DEJA_CYCLE_FUZZY_KEY` |
 | `Shift+←` | Cycle fuzzy preset backward (loose → smart → tight) | `DEJA_CYCLE_FUZZY_BACK_KEY` |
+| `Shift+↑` | Toggle ghost text on an empty prompt (persisted, global) | `DEJA_TOGGLE_EMPTY_KEY` |
 | `Tab` | Open inline alternatives picker | `DEJA_CYCLE_KEY` |
 | `Ctrl+X` | Suppress current suggestion (session-wide) | `DEJA_TOGGLE_KEY` |
 | _(unbound)_ | Dismiss the current ghost (this line only) | `DEJA_DISMISS_KEY` |
@@ -148,8 +149,11 @@ Every binding above can be remapped by exporting the matching env var **before**
 
 ```bash
 # defaults
-export DEJA_CYCLE_KEY='^I'   # Tab    → cycle alternatives
-export DEJA_TOGGLE_KEY='^X'  # Ctrl+X → suppress for the session
+export DEJA_CYCLE_KEY='^I'                 # Tab     → cycle alternatives
+export DEJA_TOGGLE_KEY='^X'                # Ctrl+X  → suppress for the session
+export DEJA_CYCLE_FUZZY_KEY='^[[1;2C'      # Shift+→ → next fuzzy preset
+export DEJA_CYCLE_FUZZY_BACK_KEY='^[[1;2D' # Shift+← → previous fuzzy preset
+export DEJA_TOGGLE_EMPTY_KEY='^[[1;2A'     # Shift+↑ → flip empty-prompt suggestions
 # these are unbound by default (→ and Ctrl+→ already accept via wrapped widgets):
 export DEJA_ACCEPT_KEY=       # accept full suggestion on a dedicated key
 export DEJA_WORD_ACCEPT_KEY=  # accept the next word on a dedicated key
@@ -207,7 +211,7 @@ export DEJA_FUZZY=smart   # before the daemon starts; takes precedence over the 
 
 ---
 
-## Suggestions on an empty prompt
+## Suppressing ghost text on an empty prompt
 
 By default, on a fresh prompt — before you've typed anything — Deja predicts the command you're most likely to run next, based on command-sequence, frecency, and directory signals, and shows it as ghost text. If you'd rather see nothing until you start typing, turn empty-prompt suggestions off:
 
@@ -215,8 +219,16 @@ By default, on a fresh prompt — before you've typed anything — Deja predicts
 deja empty            # show whether empty-prompt suggestions are on
 deja empty off        # never suggest on an empty prompt (aliases: deja empty hide)
 deja empty on         # restore the default (aliases: deja empty show)
-deja empty toggle     # flip the current setting
+deja empty toggle     # flip the setting, printing just the new state (on|off)
 ```
+
+Or flip it without leaving the line — press `Shift+↑` at any prompt. The ghost appears or disappears in the same frame, and a picker-style confirmation shows the new state below the prompt:
+
+```
+deja: empty   *on*    off
+```
+
+Rebind via `DEJA_TOGGLE_EMPTY_KEY` (set it to empty to leave `Shift+↑` unbound; tmux users may need `set -g xterm-keys on` for the default Shift+arrow sequences to pass through). Note that — like fuzzy cycling — the keypress changes the persisted, global setting, not just the current session.
 
 Changes take effect immediately if the daemon is running and persist across restarts (saved to `~/.local/share/deja/config`). Override per shell session with an environment variable:
 

--- a/cmd/deja/daemon.go
+++ b/cmd/deja/daemon.go
@@ -58,9 +58,13 @@ func runDaemon(args []string) {
 		fmt.Fprintf(os.Stderr, "deja daemon: %v\n", err)
 		os.Exit(1)
 	}
-	fuzzy, src := config.LoadFuzzy(cfgDir)
+	fuzzy, fsrc := config.LoadFuzzy(cfgDir)
 	state.SetFuzzy(fuzzy)
-	fmt.Fprintf(os.Stderr, "deja daemon: fuzzy=%s (%s)\n", fuzzy, sourceLabel(src))
+	fmt.Fprintf(os.Stderr, "deja daemon: fuzzy=%s (%s)\n", fuzzy, sourceLabel(fsrc, config.EnvFuzzy))
+
+	showEmpty, esrc := config.LoadEmpty(cfgDir)
+	state.SetShowEmpty(showEmpty)
+	fmt.Fprintf(os.Stderr, "deja daemon: empty=%s (%s)\n", config.FormatEmpty(showEmpty), sourceLabel(esrc, config.EnvEmpty))
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -72,10 +76,10 @@ func runDaemon(args []string) {
 	}
 }
 
-func sourceLabel(s config.Source) string {
+func sourceLabel(s config.Source, envName string) string {
 	switch s {
 	case config.SourceEnv:
-		return "DEJA_FUZZY"
+		return envName
 	case config.SourceFile:
 		return "config file"
 	default:

--- a/cmd/deja/empty.go
+++ b/cmd/deja/empty.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/giammarcoferranti/deja/internal/config"
+	"github.com/giammarcoferranti/deja/internal/daemon"
+)
+
+func runEmpty(args []string) {
+	fs := flag.NewFlagSet("empty", flag.ContinueOnError)
+	fs.Usage = func() {
+		w := os.Stdout
+		fs.SetOutput(w)
+		fmt.Fprintln(w, "deja empty — show or change whether deja suggests on an empty prompt")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Usage:")
+		fmt.Fprintln(w, "  deja empty                 show whether empty-prompt suggestions are on")
+		fmt.Fprintln(w, "  deja empty on|off          turn empty-prompt suggestions on or off (aliases: show|hide)")
+		fmt.Fprintln(w, "  deja empty toggle          flip the current setting")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "When on (the default), deja predicts the next command on a fresh prompt using")
+		fmt.Fprintln(w, "command-sequence, frecency, and directory signals. When off, ghost text only")
+		fmt.Fprintln(w, "appears once you start typing.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Changes take effect immediately if the daemon is running, and are persisted")
+		fmt.Fprintln(w, "to ~/.local/share/deja/config so they survive restarts.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Override at session level with: export DEJA_EMPTY=off")
+		fmt.Fprintln(w, "This is a global, persisted setting — distinct from Ctrl+X, which suppresses")
+		fmt.Fprintln(w, "all suggestions for the current shell session only.")
+	}
+	parseFlags(fs, args)
+
+	rest := fs.Args()
+	switch len(rest) {
+	case 0:
+		printEmptyStatus(readCurrentEmpty())
+	case 1:
+		if strings.ToLower(strings.TrimSpace(rest[0])) == "toggle" {
+			commitEmpty(!readCurrentEmpty())
+		} else {
+			setEmpty(rest[0])
+		}
+	default:
+		fmt.Fprintln(os.Stderr, "deja empty: too many arguments")
+		printEmptyStatus(readCurrentEmpty())
+		os.Exit(2)
+	}
+}
+
+// readCurrentEmpty returns the effective setting. Prefer asking the daemon (it
+// knows the live in-memory value); fall back to the persisted file + env.
+//
+// GetConfigResp.Empty is a *bool: a daemon that predates the setting sends nil,
+// and we then fall back to the persisted default rather than trusting a
+// zero-valued false.
+func readCurrentEmpty() bool {
+	if resp, err := dialGetConfig(); err == nil && resp.Empty != nil {
+		return *resp.Empty
+	}
+	dir, err := dataDir()
+	if err != nil {
+		return config.EmptyDefault
+	}
+	show, _ := config.LoadEmpty(dir)
+	return show
+}
+
+// applyEmpty persists show to the config file and pushes it to the running
+// daemon (if reachable). prev is the **file-persisted** previous value; it
+// reflects what the file said before the write, not the env-resolved effective
+// value, so callers can print an accurate diff.
+func applyEmpty(show bool) (prev bool, hadFile, daemonApplied bool, err error) {
+	dir, derr := dataDir()
+	if derr != nil {
+		return config.EmptyDefault, false, false, derr
+	}
+	prev, hadFile = config.LoadEmptyFile(dir)
+
+	if err := config.SaveEmpty(dir, show); err != nil {
+		return prev, hadFile, false, fmt.Errorf("persist: %w", err)
+	}
+
+	if _, derr := dialSetConfig(daemon.SetConfigReq{Empty: &show}); derr == nil {
+		daemonApplied = true
+	}
+	return prev, hadFile, daemonApplied, nil
+}
+
+func setEmpty(raw string) {
+	show, err := config.ParseEmpty(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "deja empty: %v\n", err)
+		printEmptyStatus(readCurrentEmpty())
+		os.Exit(2)
+	}
+	commitEmpty(show)
+}
+
+func commitEmpty(show bool) {
+	prev, hadFile, daemonApplied, err := applyEmpty(show)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "deja empty: %v\n", err)
+		os.Exit(1)
+	}
+
+	switch {
+	case !hadFile:
+		fmt.Printf("empty: (unset) → %s\n", config.FormatEmpty(show))
+	case prev == show:
+		fmt.Printf("empty: %s (unchanged)\n", config.FormatEmpty(show))
+	default:
+		fmt.Printf("empty: %s → %s\n", config.FormatEmpty(prev), config.FormatEmpty(show))
+	}
+	if !daemonApplied {
+		fmt.Println("note: daemon not reachable; new setting will apply on next start")
+	}
+	// Compare the env override semantically: DEJA_EMPTY=true and "on" mean the
+	// same thing, so a raw string compare would warn spuriously.
+	if env := strings.TrimSpace(os.Getenv(config.EnvEmpty)); env != "" {
+		if envShow, perr := config.ParseEmpty(env); perr == nil && envShow != show {
+			fmt.Printf("note: %s=%s is set in your environment and will override on next daemon start\n", config.EnvEmpty, env)
+		}
+	}
+}
+
+func printEmptyStatus(current bool) {
+	fmt.Printf("empty-prompt suggestions: %s\n\n", config.FormatEmpty(current))
+	if current {
+		fmt.Println("deja predicts the next command on a fresh (empty) prompt and shows it as ghost text.")
+	} else {
+		fmt.Println("deja shows nothing on a fresh (empty) prompt; suggestions start once you type.")
+	}
+	fmt.Println()
+	fmt.Println("change with:  deja empty <on|off>   (aliases: show|hide)")
+	fmt.Println("flip it:      deja empty toggle")
+	fmt.Println("set in shell: export DEJA_EMPTY=off")
+}

--- a/cmd/deja/empty.go
+++ b/cmd/deja/empty.go
@@ -15,12 +15,12 @@ func runEmpty(args []string) {
 	fs.Usage = func() {
 		w := os.Stdout
 		fs.SetOutput(w)
-		fmt.Fprintln(w, "deja empty — show or change whether deja suggests on an empty prompt")
+		fmt.Fprintln(w, "deja empty — suppress ghost text suggestions on an empty prompt")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "Usage:")
 		fmt.Fprintln(w, "  deja empty                 show whether empty-prompt suggestions are on")
 		fmt.Fprintln(w, "  deja empty on|off          turn empty-prompt suggestions on or off (aliases: show|hide)")
-		fmt.Fprintln(w, "  deja empty toggle          flip the current setting")
+		fmt.Fprintln(w, "  deja empty toggle          flip the setting and print just the new state")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "When on (the default), deja predicts the next command on a fresh prompt using")
 		fmt.Fprintln(w, "command-sequence, frecency, and directory signals. When off, ghost text only")
@@ -30,6 +30,7 @@ func runEmpty(args []string) {
 		fmt.Fprintln(w, "to ~/.local/share/deja/config so they survive restarts.")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "Override at session level with: export DEJA_EMPTY=off")
+		fmt.Fprintln(w, "In zsh, press Shift+↑ to flip the setting without typing.")
 		fmt.Fprintln(w, "This is a global, persisted setting — distinct from Ctrl+X, which suppresses")
 		fmt.Fprintln(w, "all suggestions for the current shell session only.")
 	}
@@ -41,7 +42,7 @@ func runEmpty(args []string) {
 		printEmptyStatus(readCurrentEmpty())
 	case 1:
 		if strings.ToLower(strings.TrimSpace(rest[0])) == "toggle" {
-			commitEmpty(!readCurrentEmpty())
+			toggleEmpty()
 		} else {
 			setEmpty(rest[0])
 		}
@@ -128,6 +129,19 @@ func commitEmpty(show bool) {
 	}
 }
 
+// toggleEmpty flips the setting and prints just the new state (`on` or `off`)
+// to stdout. The zsh Shift+↑ binding consumes that single token directly, the
+// same way it consumes `deja fuzzy cycle`; humans use `deja empty <on|off>` for
+// prose.
+func toggleEmpty() {
+	show := !readCurrentEmpty()
+	if _, _, _, err := applyEmpty(show); err != nil {
+		fmt.Fprintf(os.Stderr, "deja empty: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(config.FormatEmpty(show))
+}
+
 func printEmptyStatus(current bool) {
 	fmt.Printf("empty-prompt suggestions: %s\n\n", config.FormatEmpty(current))
 	if current {
@@ -137,6 +151,6 @@ func printEmptyStatus(current bool) {
 	}
 	fmt.Println()
 	fmt.Println("change with:  deja empty <on|off>   (aliases: show|hide)")
-	fmt.Println("flip it:      deja empty toggle")
+	fmt.Println("flip it:      deja empty toggle     (or press Shift+↑ in zsh)")
 	fmt.Println("set in shell: export DEJA_EMPTY=off")
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -34,6 +34,8 @@ func main() {
 		runPing(args)
 	case "fuzzy":
 		runFuzzy(args)
+	case "empty":
+		runEmpty(args)
 	case "version", "-v", "--version":
 		printVersion()
 	case "-h", "--help", "help":
@@ -60,5 +62,6 @@ subcommands:
   record   record an executed command (used by shell hooks)
   ping     check if the daemon is running
   fuzzy    show or change the fuzzy strictness preset
+  empty    show or change whether deja suggests on an empty prompt
   version  print the version, commit, and build date`)
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -62,6 +62,6 @@ subcommands:
   record   record an executed command (used by shell hooks)
   ping     check if the daemon is running
   fuzzy    show or change the fuzzy strictness preset
-  empty    show or change whether deja suggests on an empty prompt
+  empty    suppress ghost text suggestions on an empty prompt
   version  print the version, commit, and build date`)
 }

--- a/cmd/deja/query.go
+++ b/cmd/deja/query.go
@@ -104,6 +104,17 @@ func dialAndSuggest(buffer, dir, prev string) (daemon.SuggestResp, error) {
 // a freshly opened SQLite connection. Slower (cold reads) but keeps the
 // shell responsive when the daemon is down.
 func fallbackSuggest(buffer, dir, prev string) daemon.SuggestResp {
+	// Mirror the daemon's empty-prompt gate (handlers.go Suggest): when the
+	// user has opted out of predictions on a fresh prompt, don't even open the
+	// database. Match the daemon's exact "" test, not a trimmed one.
+	if buffer == "" {
+		if cfgDir, err := dataDir(); err == nil {
+			if show, _ := config.LoadEmpty(cfgDir); !show {
+				return daemon.SuggestResp{}
+			}
+		}
+	}
+
 	path, err := dbPath()
 	if err != nil {
 		return daemon.SuggestResp{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,12 @@
-// Package config persists user-tunable settings (currently just the fuzzy
-// strictness preset) in a tiny key=value file. The daemon reads it once at
-// startup; the `deja fuzzy` CLI writes to it when the user changes the preset.
+// Package config persists user-tunable settings (the fuzzy strictness preset
+// and whether deja suggests on an empty prompt) in a tiny key=value file. The
+// daemon reads it once at startup; the `deja fuzzy` / `deja empty` CLIs write
+// to it when the user changes a setting.
 package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,11 +17,21 @@ import (
 const (
 	fileName = "config"
 	fuzzyKey = "fuzzy"
+	emptyKey = "empty_suggestions"
 
 	// EnvFuzzy is the environment variable that overrides the persisted
 	// fuzzy preset at daemon startup.
 	EnvFuzzy = "DEJA_FUZZY"
+
+	// EnvEmpty is the environment variable that overrides the persisted
+	// empty-prompt suggestion setting at daemon startup.
+	EnvEmpty = "DEJA_EMPTY"
 )
+
+// EmptyDefault is whether deja suggests on an empty prompt when nothing else is
+// configured. True preserves the historical behavior (predict the next command
+// on a fresh prompt).
+const EmptyDefault = true
 
 // Source indicates where a resolved value came from.
 type Source int
@@ -65,6 +77,68 @@ func LoadFuzzyFile(dir string) (scorer.Fuzzy, bool) {
 // SaveFuzzy atomically persists the fuzzy preset to the config file in dir.
 func SaveFuzzy(dir string, f scorer.Fuzzy) error {
 	return writeKey(dir, fuzzyKey, f.String())
+}
+
+// ParseEmpty interprets a user-supplied on/off value for empty-prompt
+// suggestions. Empty input yields EmptyDefault (mirroring ParseFuzzy) so that
+// the "unset means default" filtering lives in the loaders, not here. Besides
+// on/off it accepts show/hide, true/false, 1/0, and yes/no.
+func ParseEmpty(s string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return EmptyDefault, nil
+	case "on", "show", "true", "1", "yes":
+		return true, nil
+	case "off", "hide", "false", "0", "no":
+		return false, nil
+	default:
+		return EmptyDefault, fmt.Errorf("unknown empty setting %q (want on|off)", s)
+	}
+}
+
+// FormatEmpty renders the setting as the canonical persisted/display token.
+func FormatEmpty(show bool) string {
+	if show {
+		return "on"
+	}
+	return "off"
+}
+
+// LoadEmpty resolves whether empty-prompt suggestions are shown by checking
+// DEJA_EMPTY first, then the persisted config file in dir, then falling back to
+// EmptyDefault. The second return identifies which source supplied the value.
+func LoadEmpty(dir string) (bool, Source) {
+	if v := strings.TrimSpace(os.Getenv(EnvEmpty)); v != "" {
+		if b, err := ParseEmpty(v); err == nil {
+			return b, SourceEnv
+		}
+	}
+	if v, ok := readKey(dir, emptyKey); ok {
+		if b, err := ParseEmpty(v); err == nil {
+			return b, SourceFile
+		}
+	}
+	return EmptyDefault, SourceDefault
+}
+
+// LoadEmptyFile reads only the persisted empty-prompt setting, ignoring
+// DEJA_EMPTY. The second return is false when no valid file value is present.
+//
+// Use this (not LoadEmpty) to diff the user's *persisted* state, e.g. to print
+// "empty: on → off"; LoadEmpty resolves env-first and so reports the effective
+// value, which lies about what a file change did.
+func LoadEmptyFile(dir string) (bool, bool) {
+	if v, ok := readKey(dir, emptyKey); ok {
+		if b, err := ParseEmpty(v); err == nil {
+			return b, true
+		}
+	}
+	return EmptyDefault, false
+}
+
+// SaveEmpty atomically persists the empty-prompt suggestion setting to dir.
+func SaveEmpty(dir string, show bool) error {
+	return writeKey(dir, emptyKey, FormatEmpty(show))
 }
 
 func readKey(dir, key string) (string, bool) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -122,6 +122,163 @@ func TestSaveFuzzy_PreservesUnrelatedLines(t *testing.T) {
 	}
 }
 
+func TestLoadEmpty_DefaultWhenEmpty(t *testing.T) {
+	t.Setenv(EnvEmpty, "")
+	dir := t.TempDir()
+
+	got, src := LoadEmpty(dir)
+	if got != EmptyDefault || src != SourceDefault {
+		t.Errorf("LoadEmpty(empty) = (%v, %v), want (%v, %v)", got, src, EmptyDefault, SourceDefault)
+	}
+}
+
+func TestLoadEmpty_FromFile(t *testing.T) {
+	t.Setenv(EnvEmpty, "")
+	dir := t.TempDir()
+
+	if err := SaveEmpty(dir, false); err != nil {
+		t.Fatalf("SaveEmpty: %v", err)
+	}
+
+	got, src := LoadEmpty(dir)
+	if got != false || src != SourceFile {
+		t.Errorf("LoadEmpty(file=off) = (%v, %v), want (false, %v)", got, src, SourceFile)
+	}
+}
+
+func TestLoadEmpty_EnvOverridesFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveEmpty(dir, true); err != nil {
+		t.Fatalf("SaveEmpty: %v", err)
+	}
+	t.Setenv(EnvEmpty, "off")
+
+	got, src := LoadEmpty(dir)
+	if got != false || src != SourceEnv {
+		t.Errorf("LoadEmpty(env=off, file=on) = (%v, %v), want (false, %v)", got, src, SourceEnv)
+	}
+}
+
+func TestLoadEmpty_InvalidEnvFallsThrough(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveEmpty(dir, false); err != nil {
+		t.Fatalf("SaveEmpty: %v", err)
+	}
+	t.Setenv(EnvEmpty, "bananas")
+
+	got, src := LoadEmpty(dir)
+	if got != false || src != SourceFile {
+		t.Errorf("LoadEmpty(env=invalid) should fall through to file, got (%v, %v)", got, src)
+	}
+}
+
+func TestLoadEmptyFile_IgnoresEnv(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveEmpty(dir, false); err != nil {
+		t.Fatalf("SaveEmpty: %v", err)
+	}
+	t.Setenv(EnvEmpty, "on")
+
+	got, hadFile := LoadEmptyFile(dir)
+	if !hadFile || got != false {
+		t.Errorf("LoadEmptyFile(env=on, file=off) = (%v, %v), want (false, true)", got, hadFile)
+	}
+}
+
+func TestLoadEmptyFile_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(EnvEmpty, "off")
+
+	got, hadFile := LoadEmptyFile(dir)
+	if hadFile || got != EmptyDefault {
+		t.Errorf("LoadEmptyFile(no file) = (%v, %v), want (default, false)", got, hadFile)
+	}
+}
+
+func TestSaveEmpty_OverwritesPreviousValue(t *testing.T) {
+	t.Setenv(EnvEmpty, "")
+	dir := t.TempDir()
+
+	if err := SaveEmpty(dir, false); err != nil {
+		t.Fatalf("SaveEmpty off: %v", err)
+	}
+	if err := SaveEmpty(dir, true); err != nil {
+		t.Fatalf("SaveEmpty on: %v", err)
+	}
+
+	got, _ := LoadEmpty(dir)
+	if got != true {
+		t.Errorf("after overwrite want on, got %v", got)
+	}
+}
+
+// TestSaveEmpty_CoexistsWithFuzzy verifies the two settings share the config
+// file without clobbering each other (writeKey rewrites only its own key).
+func TestSaveEmpty_CoexistsWithFuzzy(t *testing.T) {
+	t.Setenv(EnvEmpty, "")
+	t.Setenv(EnvFuzzy, "")
+	dir := t.TempDir()
+	cfg := dir + "/config"
+
+	if err := os.WriteFile(cfg, []byte("# header comment\nunrelated=value\nfuzzy=loose\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := SaveEmpty(dir, false); err != nil {
+		t.Fatalf("SaveEmpty: %v", err)
+	}
+
+	data, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(data)
+	if !contains(s, "unrelated=value") {
+		t.Errorf("unrelated line dropped: %q", s)
+	}
+	if !contains(s, "fuzzy=loose") {
+		t.Errorf("fuzzy line dropped: %q", s)
+	}
+	if !contains(s, "empty_suggestions=off") {
+		t.Errorf("empty_suggestions not written: %q", s)
+	}
+}
+
+func TestParseEmpty_Variants(t *testing.T) {
+	trueCases := []string{"on", "ON", " on ", "show", "true", "1", "yes"}
+	for _, in := range trueCases {
+		got, err := ParseEmpty(in)
+		if err != nil || got != true {
+			t.Errorf("ParseEmpty(%q) = (%v, %v), want (true, nil)", in, got, err)
+		}
+	}
+
+	falseCases := []string{"off", "OFF", "hide", "false", "0", "no"}
+	for _, in := range falseCases {
+		got, err := ParseEmpty(in)
+		if err != nil || got != false {
+			t.Errorf("ParseEmpty(%q) = (%v, %v), want (false, nil)", in, got, err)
+		}
+	}
+
+	// Empty input yields the default with no error (mirrors ParseFuzzy).
+	if got, err := ParseEmpty(""); err != nil || got != EmptyDefault {
+		t.Errorf("ParseEmpty(\"\") = (%v, %v), want (%v, nil)", got, err, EmptyDefault)
+	}
+
+	if _, err := ParseEmpty("maybe"); err == nil {
+		t.Error("ParseEmpty(maybe) should error")
+	}
+}
+
+func TestFormatEmpty(t *testing.T) {
+	if FormatEmpty(true) != "on" {
+		t.Errorf("FormatEmpty(true) = %q, want on", FormatEmpty(true))
+	}
+	if FormatEmpty(false) != "off" {
+		t.Errorf("FormatEmpty(false) = %q, want off", FormatEmpty(false))
+	}
+}
+
 func contains(s, sub string) bool {
 	return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0)
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -303,4 +304,133 @@ func findStat(stats []store.CommandStat, cmd string) *store.CommandStat {
 		}
 	}
 	return nil
+}
+
+func ptrBool(b bool) *bool { return &b }
+
+// TestSuggest_EmptyPromptGate covers the ShowEmpty gate: on an empty buffer the
+// daemon predicts by default but returns nothing when the user opts out, while
+// a non-empty buffer is never affected by the setting.
+func TestSuggest_EmptyPromptGate(t *testing.T) {
+	db := newTestDB(t)
+	seed(t, db)
+
+	state, err := Load(db)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	now := time.Date(2026, 4, 16, 10, 10, 0, 0, time.UTC)
+
+	// Default (showEmpty=true): an empty buffer yields a prediction.
+	if resp := state.Suggest(SuggestReq{Buffer: "", Dir: "/repo"}, now); resp.Suggestion == "" {
+		t.Errorf("default empty-prompt suggest returned nothing, want a prediction")
+	}
+
+	// Opted out: an empty buffer yields nothing.
+	state.SetShowEmpty(false)
+	if resp := state.Suggest(SuggestReq{Buffer: "", Dir: "/repo"}, now); resp.Suggestion != "" || len(resp.Alternatives) != 0 {
+		t.Errorf("with showEmpty=false, empty-prompt suggest = %+v, want empty", resp)
+	}
+
+	// The gate is scoped to an exactly-empty buffer — a real buffer still ranks.
+	if resp := state.Suggest(SuggestReq{Buffer: "git c", Dir: "/repo"}, now); resp.Suggestion != "git commit -m" {
+		t.Errorf("non-empty buffer must ignore showEmpty; got %q", resp.Suggestion)
+	}
+
+	// Re-enabled: predictions return.
+	state.SetShowEmpty(true)
+	if resp := state.Suggest(SuggestReq{Buffer: "", Dir: "/repo"}, now); resp.Suggestion == "" {
+		t.Errorf("re-enabled empty-prompt suggest returned nothing, want a prediction")
+	}
+}
+
+// TestSetGetConfig_Empty exercises the Empty (*bool) round-trip: GetConfig
+// echoes a non-nil pointer, nil in a request leaves the setting alone, and an
+// invalid fuzzy value in the same request must not drop a valid empty change.
+func TestSetGetConfig_Empty(t *testing.T) {
+	state, err := Load(newTestDB(t))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Default is reported as a non-nil pointer to true.
+	if got := state.GetConfig(); got.Empty == nil || *got.Empty != true {
+		t.Fatalf("GetConfig default Empty = %v, want *true", got.Empty)
+	}
+
+	// Setting empty=false takes effect and is echoed.
+	resp := state.SetConfig(SetConfigReq{Empty: ptrBool(false)})
+	if resp.Error != "" {
+		t.Fatalf("SetConfig(empty=false) error: %s", resp.Error)
+	}
+	if resp.Empty == nil || *resp.Empty != false {
+		t.Errorf("SetConfig echo Empty = %v, want *false", resp.Empty)
+	}
+	if state.ShowEmpty() {
+		t.Error("ShowEmpty() still true after SetConfig(empty=false)")
+	}
+	if got := state.GetConfig(); got.Empty == nil || *got.Empty != false {
+		t.Errorf("GetConfig Empty = %v, want *false", got.Empty)
+	}
+
+	// A nil Empty leaves the setting alone (only fuzzy changes here).
+	if resp := state.SetConfig(SetConfigReq{Fuzzy: "tight"}); resp.Error != "" {
+		t.Fatalf("SetConfig(fuzzy=tight) error: %s", resp.Error)
+	}
+	if state.ShowEmpty() {
+		t.Error("ShowEmpty() flipped by a request that omitted Empty")
+	}
+
+	// A rejected fuzzy value must not drop a valid empty change applied in the
+	// same request.
+	resp = state.SetConfig(SetConfigReq{Fuzzy: "bogus", Empty: ptrBool(true)})
+	if resp.Error == "" {
+		t.Error("SetConfig(fuzzy=bogus) should report an error")
+	}
+	if !state.ShowEmpty() {
+		t.Error("valid empty change dropped when the request's fuzzy value was rejected")
+	}
+	if resp.Empty == nil || *resp.Empty != true {
+		t.Errorf("rejected-fuzzy SetConfig echo Empty = %v, want *true", resp.Empty)
+	}
+}
+
+// TestState_ConcurrentToggleShowEmpty runs the empty-prompt gate under -race:
+// SetShowEmpty (write lock) races empty-buffer Suggest calls (ShowEmpty read
+// lock + early return) with no data race or panic.
+func TestState_ConcurrentToggleShowEmpty(t *testing.T) {
+	db := newTestDB(t)
+	seed(t, db)
+
+	state, err := Load(db)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		on := true
+		for ctx.Err() == nil {
+			state.SetShowEmpty(on)
+			on = !on
+		}
+	}()
+
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ctx.Err() == nil {
+				_ = state.Suggest(SuggestReq{Buffer: "", Dir: "/repo", Prev: "git status"}, time.Now())
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -13,6 +13,16 @@ const maxAlternatives = 4
 // Suggest runs the ranker on the current in-memory snapshot and returns the
 // top result plus up to maxAlternatives follow-ups.
 func (s *State) Suggest(req SuggestReq, now time.Time) SuggestResp {
+	// Empty buffer is the "predict the next command on a fresh prompt" case
+	// (scorer.computeFuzzy special-cases buffer == "" to a constant score,
+	// letting frecency/sequence/dir decide). When the user has opted out of
+	// that, short-circuit before the (possibly cold) SeqCounts read. Match the
+	// scorer's exact "" test — a whitespace-only buffer is ordinary fuzzy
+	// matching, not this prediction, so it must not be suppressed.
+	if req.Buffer == "" && !s.ShowEmpty() {
+		return SuggestResp{}
+	}
+
 	seq, _ := s.SeqCounts(req.Prev)
 
 	// Hold the RLock for the duration of Rank: stats is a slice that Record
@@ -113,17 +123,28 @@ func (s *State) Ping() PingResp {
 // SetConfig applies runtime settings sent by the CLI. Invalid values are
 // rejected and the previous setting is preserved.
 func (s *State) SetConfig(req SetConfigReq) SetConfigResp {
+	// Apply the infallible setting first, so a rejected fuzzy value in the same
+	// request can't silently drop a valid empty change on the early return.
+	if req.Empty != nil {
+		s.SetShowEmpty(*req.Empty)
+	}
 	if req.Fuzzy != "" {
 		f, err := scorer.ParseFuzzy(req.Fuzzy)
 		if err != nil {
-			return SetConfigResp{Fuzzy: s.GetFuzzy().String(), Error: err.Error()}
+			return s.setConfigResp(err.Error())
 		}
 		s.SetFuzzy(f)
 	}
-	return SetConfigResp{Fuzzy: s.GetFuzzy().String()}
+	return s.setConfigResp("")
+}
+
+func (s *State) setConfigResp(errMsg string) SetConfigResp {
+	show := s.ShowEmpty()
+	return SetConfigResp{Fuzzy: s.GetFuzzy().String(), Empty: &show, Error: errMsg}
 }
 
 // GetConfig returns the current runtime settings.
 func (s *State) GetConfig() GetConfigResp {
-	return GetConfigResp{Fuzzy: s.GetFuzzy().String()}
+	show := s.ShowEmpty()
+	return GetConfigResp{Fuzzy: s.GetFuzzy().String(), Empty: &show}
 }

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -36,20 +36,30 @@ type PingResp struct {
 	Pong bool `json:"pong"`
 }
 
-// SetConfigReq mutates daemon-side settings. Empty fields mean "leave alone".
+// SetConfigReq mutates daemon-side settings. An omitted field means "leave
+// alone": "" for Fuzzy, nil for Empty. Empty is a *bool (not bool) so a
+// pointer-to-false — "turn suggestions off" — is distinguishable from absent
+// (omitempty only drops nil, never a non-nil pointer to false).
 type SetConfigReq struct {
 	Fuzzy string `json:"fuzzy,omitempty"`
+	Empty *bool  `json:"empty,omitempty"`
 }
 
 // SetConfigResp echoes the resulting effective settings. Error is non-empty
 // when the request was rejected (invalid value); the previous setting is kept.
+// Empty is a pointer for the same reason it is in GetConfigResp.
 type SetConfigResp struct {
 	Fuzzy string `json:"fuzzy"`
+	Empty *bool  `json:"empty,omitempty"`
 	Error string `json:"error,omitempty"`
 }
 
 type GetConfigReq struct{}
 
+// GetConfigResp reports the daemon's current settings. Empty is a *bool so a
+// client talking to an older daemon that predates this field decodes nil (and
+// can fall back to its own config default) rather than a misleading false.
 type GetConfigResp struct {
 	Fuzzy string `json:"fuzzy"`
+	Empty *bool  `json:"empty,omitempty"`
 }

--- a/internal/daemon/state.go
+++ b/internal/daemon/state.go
@@ -8,6 +8,14 @@ import (
 	"gorm.io/gorm"
 )
 
+// defaultShowEmpty is the in-memory default for whether the daemon suggests on
+// an empty prompt. It must track config.EmptyDefault, but the daemon stays
+// persistence-agnostic (it never imports config — the CLI loads the persisted
+// value and pushes it via SetShowEmpty at startup), mirroring how fuzzy
+// defaults to scorer.FuzzyDefault rather than anything in config. This literal
+// therefore only surfaces in tests that call Load without SetShowEmpty.
+const defaultShowEmpty = true
+
 // State is the in-memory snapshot the daemon serves suggestions from.
 // Reads are cheap and concurrent; writes (from Record) are brief and rare.
 type State struct {
@@ -17,6 +25,7 @@ type State struct {
 	seqByPrev map[string]map[string]int // prev → next → count, filled lazily
 	dirCounts map[string]map[string]int // cmd  → dir  → count
 	fuzzy     scorer.Fuzzy              // strictness preset for fuzzy matching
+	showEmpty bool                      // suggest on an empty prompt?
 }
 
 // Load warms state from SQLite. It preloads only the dirCounts for the
@@ -42,6 +51,7 @@ func Load(db *gorm.DB) (*State, error) {
 		seqByPrev: make(map[string]map[string]int),
 		dirCounts: dirCounts,
 		fuzzy:     scorer.FuzzyDefault,
+		showEmpty: defaultShowEmpty,
 	}, nil
 }
 
@@ -57,6 +67,20 @@ func (s *State) GetFuzzy() scorer.Fuzzy {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.fuzzy
+}
+
+// SetShowEmpty controls whether Suggest returns a prediction on an empty prompt.
+func (s *State) SetShowEmpty(show bool) {
+	s.mu.Lock()
+	s.showEmpty = show
+	s.mu.Unlock()
+}
+
+// ShowEmpty reports whether Suggest returns a prediction on an empty prompt.
+func (s *State) ShowEmpty() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.showEmpty
 }
 
 // SeqCounts returns the cached next-command counts for a given prev,

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -1,0 +1,103 @@
+package shell
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var (
+	builtinActionsRe = regexp.MustCompile(`(?m)^_DEJA_BUILTIN_ACTIONS=\(([^)]*)\)`)
+	bindkeyRe        = regexp.MustCompile(`bindkey\s+"[^"]*"\s+deja-(\w+)`)
+)
+
+// builtinActions parses the _DEJA_BUILTIN_ACTIONS array out of the script. Every
+// entry gets a generated `_deja_widget_<action>` wrapper and a `deja-<action>`
+// zle widget, so it is the authoritative list of bindable actions.
+func builtinActions(t *testing.T) map[string]bool {
+	t.Helper()
+
+	m := builtinActionsRe.FindStringSubmatch(ZshInit())
+	if m == nil {
+		t.Fatal("could not find _DEJA_BUILTIN_ACTIONS assignment in zsh.sh")
+	}
+	actions := make(map[string]bool)
+	for _, a := range strings.Fields(m[1]) {
+		actions[a] = true
+	}
+	return actions
+}
+
+// TestZshInit_TogglesEmptyOnShiftUp pins the Shift+↑ wiring: the action is
+// registered, the key has its documented default, and the binding names that
+// action. A typo in any one of the three leaves the key silently dead.
+func TestZshInit_TogglesEmptyOnShiftUp(t *testing.T) {
+	script := ZshInit()
+
+	if !builtinActions(t)["toggle_empty"] {
+		t.Error("toggle_empty missing from _DEJA_BUILTIN_ACTIONS; deja-toggle_empty widget won't be created")
+	}
+	// Shift+↑ in xterm-style terminals. `=` (not `:=`) so an explicitly-empty
+	// value survives and leaves the key unbound.
+	if !strings.Contains(script, `: ${DEJA_TOGGLE_EMPTY_KEY='^[[1;2A'}`) {
+		t.Error("DEJA_TOGGLE_EMPTY_KEY default (Shift+up, ^[[1;2A) not declared as expected")
+	}
+	if !strings.Contains(script, `bindkey "$DEJA_TOGGLE_EMPTY_KEY"`) {
+		t.Error("DEJA_TOGGLE_EMPTY_KEY is never passed to bindkey")
+	}
+}
+
+// TestZshInit_BindkeyActionsExist guards every key binding, not just the new
+// one: a `bindkey ... deja-<action>` whose action isn't in
+// _DEJA_BUILTIN_ACTIONS binds a nonexistent widget, which zsh reports only when
+// the user presses the key.
+func TestZshInit_BindkeyActionsExist(t *testing.T) {
+	actions := builtinActions(t)
+
+	matches := bindkeyRe.FindAllStringSubmatch(ZshInit(), -1)
+	if len(matches) == 0 {
+		t.Fatal("no `bindkey ... deja-<action>` lines found; regexp or script layout changed")
+	}
+	for _, m := range matches {
+		if !actions[m[1]] {
+			t.Errorf("bindkey references deja-%s, which is not in _DEJA_BUILTIN_ACTIONS", m[1])
+		}
+	}
+}
+
+// TestZshInit_ActionsHaveHandlers checks the other half of the contract: the
+// generated wrapper calls `_deja_<action>`, so each registered action needs a
+// function of that name.
+func TestZshInit_ActionsHaveHandlers(t *testing.T) {
+	script := ZshInit()
+
+	for action := range builtinActions(t) {
+		if !strings.Contains(script, "\n_deja_"+action+"()") {
+			t.Errorf("action %q has no _deja_%s() function", action, action)
+		}
+	}
+}
+
+// TestZshInit_Syntax parses the generated script with zsh itself, the way
+// `deja init zsh` emits it. Skipped where zsh isn't installed (some CI images).
+func TestZshInit_Syntax(t *testing.T) {
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh not installed; skipping syntax check")
+	}
+
+	// Same substitution cmd/deja/init.go performs before printing the script.
+	script := strings.ReplaceAll(ZshInit(), "{{DEJA_BIN}}", "/nonexistent/deja")
+	path := filepath.Join(t.TempDir(), "init.zsh")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	out, err := exec.Command(zsh, "-n", path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("zsh -n rejected the init script: %v\n%s", err, out)
+	}
+}

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -22,18 +22,22 @@ typeset -g DEJA_BIN="{{DEJA_BIN}}"
 # change the persisted preset instead.
 # DEJA_EMPTY (unset by default): override whether deja suggests on an empty
 # prompt for the daemon spawned by this shell. on|off (aliases show|hide). Like
-# DEJA_FUZZY it is read by the daemon at startup; use `deja empty` to change the
-# persisted setting instead. Distinct from Ctrl+X, which suppresses all
-# suggestions for this session only.
+# DEJA_FUZZY it is read by the daemon at startup; use `deja empty` or Shift+↑ to
+# change the persisted setting instead. Distinct from Ctrl+X, which suppresses
+# all suggestions for this session only.
 # DEJA_CYCLE_FUZZY_KEY / DEJA_CYCLE_FUZZY_BACK_KEY: zle key sequences bound to
 # `deja fuzzy cycle` and `deja fuzzy back`. Default to Shift+→ / Shift+←
 # (^[[1;2C / ^[[1;2D in xterm-style terminals). Set either to empty to disable
 # that direction. In tmux you may need `set -g xterm-keys on` for the default
 # Shift+arrow sequences to reach zle.
+# DEJA_TOGGLE_EMPTY_KEY: zle key sequence bound to `deja empty toggle`. Defaults
+# to Shift+↑ (^[[1;2A). Like the fuzzy keys it changes the *persisted, global*
+# setting, not just this session.
 # Use `=` (not `:=`) so an explicitly-empty value is preserved and leaves the key
 # unbound — `:=` would overwrite empty with the default, defeating "disable".
 : ${DEJA_CYCLE_FUZZY_KEY='^[[1;2C'}
 : ${DEJA_CYCLE_FUZZY_BACK_KEY='^[[1;2D'}
+: ${DEJA_TOGGLE_EMPTY_KEY='^[[1;2A'}
 # Key sequences for the core suggestion bindings. Set any to empty to leave that
 # key unbound (e.g. to hand Tab back to native completion). Values are zle key
 # strings — use `bindkey -L` or `cat -v` / `read` to discover a key's sequence.
@@ -92,7 +96,7 @@ DEJA_IGNORE_WIDGETS=(
 )
 
 typeset -ga _DEJA_BUILTIN_ACTIONS
-_DEJA_BUILTIN_ACTIONS=(clear fetch suggest accept partial_accept execute enable disable toggle cycle cycle_fuzzy cycle_fuzzy_back)
+_DEJA_BUILTIN_ACTIONS=(clear fetch suggest accept partial_accept execute enable disable toggle cycle cycle_fuzzy cycle_fuzzy_back toggle_empty)
 
 typeset -g DEJA_SESSION_ID
 if [[ -z "$DEJA_SESSION_ID" ]]; then
@@ -429,6 +433,49 @@ _deja_step_fuzzy() {
 
 _deja_cycle_fuzzy()      { _deja_step_fuzzy cycle; }
 _deja_cycle_fuzzy_back() { _deja_step_fuzzy back; }
+
+# Builds the picker-style status line: "deja: empty   *on*    off " with the
+# active state wrapped in *…*, mirroring _deja_fuzzy_picker_line.
+_deja_empty_picker_line() {
+	local current="$1" v out=""
+	for v in on off; do
+		if [[ "$v" = "$current" ]]; then
+			out+="  *${v}*"
+		else
+			out+="   ${v} "
+		fi
+	done
+	print -r -- "deja: empty${out}"
+}
+
+# Flip whether deja suggests on an empty prompt (persisted, global — same scope
+# as the fuzzy preset) and repaint synchronously so the ghost appears/disappears
+# in the same frame as the keypress.
+_deja_toggle_empty() {
+	[[ -x "$DEJA_BIN" ]] || return 0
+
+	local new
+	new="$("$DEJA_BIN" empty toggle 2>/dev/null)"
+	new="${new%$'\n'}"
+	[[ -z "$new" ]] && return 0
+
+	zle -M "$(_deja_empty_picker_line "$new")"
+
+	if (( ${+_DEJA_DISABLED} )); then
+		return 0
+	fi
+
+	# The setting only gates an empty buffer, so a non-empty line's ghost is
+	# unaffected — skip the re-fetch rather than pay for a round trip.
+	[[ -n "$BUFFER" ]] && return 0
+
+	# Sync fetch on purpose: async would put the new ghost in place only after
+	# zle returns to its read loop, so the user wouldn't see the setting change
+	# reflected until another keystroke.
+	local suggestion
+	_deja_fetch_suggestion "$BUFFER"
+	_deja_suggest "$suggestion"
+}
 
 _deja_cycle() {
 	local -i n=${#_DEJA_ALTERNATIVES}
@@ -773,6 +820,7 @@ fi
 # DEJA_DISMISS_KEY     (unset):  clear the current ghost for this line (does not suppress the session).
 # DEJA_CYCLE_FUZZY_KEY      (Shift+right): cycle the persisted fuzzy preset forward (tight→smart→loose→tight).
 # DEJA_CYCLE_FUZZY_BACK_KEY (Shift+left):  cycle backward (loose→smart→tight→loose).
+# DEJA_TOGGLE_EMPTY_KEY     (Shift+up):    flip the persisted empty-prompt suggestion setting (on↔off).
 _deja_apply_keybindings() {
 	[[ -n "$DEJA_CYCLE_KEY" ]]            && bindkey "$DEJA_CYCLE_KEY"            deja-cycle
 	[[ -n "$DEJA_TOGGLE_KEY" ]]           && bindkey "$DEJA_TOGGLE_KEY"           deja-toggle
@@ -781,6 +829,7 @@ _deja_apply_keybindings() {
 	[[ -n "$DEJA_DISMISS_KEY" ]]          && bindkey "$DEJA_DISMISS_KEY"          deja-clear
 	[[ -n "$DEJA_CYCLE_FUZZY_KEY" ]]      && bindkey "$DEJA_CYCLE_FUZZY_KEY"      deja-cycle_fuzzy
 	[[ -n "$DEJA_CYCLE_FUZZY_BACK_KEY" ]] && bindkey "$DEJA_CYCLE_FUZZY_BACK_KEY" deja-cycle_fuzzy_back
+	[[ -n "$DEJA_TOGGLE_EMPTY_KEY" ]]     && bindkey "$DEJA_TOGGLE_EMPTY_KEY"     deja-toggle_empty
 }
 
 _deja_ensure_daemon

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -20,6 +20,11 @@ typeset -g DEJA_BIN="{{DEJA_BIN}}"
 # DEJA_FUZZY (unset by default): override the fuzzy strictness preset for the
 # daemon spawned by this shell. One of loose|smart|tight. Use `deja fuzzy` to
 # change the persisted preset instead.
+# DEJA_EMPTY (unset by default): override whether deja suggests on an empty
+# prompt for the daemon spawned by this shell. on|off (aliases show|hide). Like
+# DEJA_FUZZY it is read by the daemon at startup; use `deja empty` to change the
+# persisted setting instead. Distinct from Ctrl+X, which suppresses all
+# suggestions for this session only.
 # DEJA_CYCLE_FUZZY_KEY / DEJA_CYCLE_FUZZY_BACK_KEY: zle key sequences bound to
 # `deja fuzzy cycle` and `deja fuzzy back`. Default to Shift+→ / Shift+←
 # (^[[1;2C / ^[[1;2D in xterm-style terminals). Set either to empty to disable


### PR DESCRIPTION
## Summary

Deja predicts the most-likely next command on a fresh, empty prompt and
paints it as ghost text. This adds a persisted, **opt-in** setting to turn
that off — for people who want a clean prompt until they start typing. The
default stays on, so existing behavior is unchanged.

It mirrors the existing `deja fuzzy` surface:

- `deja empty on|off|toggle` (aliases `show`/`hide`) — persisted to
  `~/.local/share/deja/config`
- `DEJA_EMPTY` env override, read by the daemon at startup
- a live push to the running daemon, so toggling takes effect without a restart

When off, the daemon (and the SQLite fallback) returns no suggestion for an
empty buffer; suggestions for a non-empty buffer are unaffected. This is a
global, persisted setting — distinct from `Ctrl+X`, which suppresses all
suggestions for the current session only.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `BREAKING CHANGE:` footer)
- [ ] Docs / chore / refactor / test / ci

## Test plan

- [x] `go test -race ./...` passes locally
- [x] `go vet ./...` clean
- [x] Added or updated tests for the change
- [x] Manually verified the shell integration (if relevant): typing, accept, alt-picker

## Notes for reviewers

- The daemon is the authoritative gate — `State.Suggest` returns early on an
  empty buffer when disabled — so the zsh side is unchanged apart from a doc
  comment, and live toggling works without regenerating the init script.
- `GetConfigResp.Empty` is a `*bool` on purpose: an older running daemon that
  predates the field sends `nil`, and the CLI then falls back to the persisted
  default rather than misreporting `off`.
- The in-shell ghost-text flow wasn't exercised here; I verified the gate
  end-to-end via the CLI (`deja query --buffer ""` with the setting on/off and
  via `DEJA_EMPTY`), plus a `-race` concurrency test over the toggle path.
