### PR TITLE
perf: don't block shell startup on a daemon liveness ping

### DIFF
--- a/cmd/deja/init.go
+++ b/cmd/deja/init.go
@@ -51,8 +51,17 @@ func runInit(args []string) {
 		os.Exit(1)
 	}
 
+	// Baked into the script so the shell can check daemon liveness with a stat on the
+	// socket instead of launching the binary for `ping` on every shell startup.
+	sock, err := sockPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "deja init: %v\n", err)
+		os.Exit(1)
+	}
+
 	initPath := filepath.Join(dir, "init.zsh")
 	script := strings.ReplaceAll(shell.ZshInit(), "{{DEJA_BIN}}", bin)
+	script = strings.ReplaceAll(script, "{{DEJA_SOCK}}", sock)
 	if err := os.WriteFile(initPath, []byte(script), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "deja init: write %s: %v\n", initPath, err)
 		os.Exit(1)

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -3,13 +3,15 @@
 # wrapped (not replaced), suggestions render via POSTDISPLAY + region_highlight,
 # and fetches run asynchronously via `zle -F` so the keystroke path never blocks.
 #
-# The DEJA_BIN value below is substituted to an absolute path by `deja init`.
+# The DEJA_BIN and DEJA_SOCK values below are substituted to absolute paths by
+# `deja init`.
 
 #--------------------------------------------------------------------#
 # 1. Globals & config                                                #
 #--------------------------------------------------------------------#
 
 typeset -g DEJA_BIN="{{DEJA_BIN}}"
+typeset -g DEJA_SOCK="{{DEJA_SOCK}}"
 
 : ${DEJA_HIGHLIGHT_STYLE:=fg=8}
 : ${DEJA_USE_ASYNC:=1}
@@ -149,7 +151,19 @@ _deja_warn_conflict() {
 _deja_ensure_daemon() {
 	[[ -x "$DEJA_BIN" ]] || return 1
 
-	# Fast path: ping succeeds, daemon is up.
+	# A socket file means a daemon is almost certainly up, so confirm it in the
+	# background rather than blocking the shell on a ~25ms process launch. `-S`
+	# also passes for a socket a crashed daemon left behind, which is what the
+	# backgrounded ping catches — until it respawns, `query` falls back to
+	# reading SQLite, so a wrong guess costs latency, never suggestions.
+	if [[ -S "$DEJA_SOCK" ]]; then
+		{ ( "$DEJA_BIN" ping >/dev/null 2>&1 || "$DEJA_BIN" daemon >/dev/null 2>&1 ) &! } 2>/dev/null
+		return 0
+	fi
+
+	# No socket: a cold start, worth blocking for so the first keystroke does not
+	# race the daemon. Ping first anyway, in case DEJA_SOCK is stale or the
+	# daemon is listening somewhere this script does not know about.
 	"$DEJA_BIN" ping >/dev/null 2>&1 && return 0
 
 	# Spawn detached. `&!` disowns immediately so the daemon outlives this shell.


### PR DESCRIPTION
> **Stack** — merge bottom-up:
>
> - #88
> - #87
> - #84
> - **#81** ⬅

## Why

`_deja_ensure_daemon` ran `deja ping` **synchronously** on every shell startup — a full
process launch, ~25 ms — before the prompt could appear. Almost always just to learn that the
daemon it started last time is still running.

## What

`deja init` now substitutes `{{DEJA_SOCK}}` alongside `{{DEJA_BIN}}`, so the script knows
where the socket is without asking the binary.

When the socket file is present, the daemon is almost certainly up, so the check moves **off
the critical path**: the ping and its respawn-on-failure run disowned in the background and
the shell returns immediately.

## What this does *not* do

**The ping is not removed, and the stat does not replace it.** Both paths still run
`deja ping`. A socket left behind by a daemon that died without cleanup also passes `-S`, so
something still has to confirm — the point is only that the shell no longer *waits* for the
answer. That backgrounded ping is the only thing that respawns a crashed daemon, so it cannot
just be deleted.

When there is no socket at all, this is a cold start, which is worth blocking for so the
first keystroke doesn't race the daemon. That path is unchanged.

Guessing wrong costs latency, not correctness: until the background respawn lands, `query`
falls back to reading SQLite directly.

Genuine socket-based liveness arrives in #84, where a `zsocket` connect *is* the check — a
stale socket fails with `ECONNREFUSED` for free and the ping disappears entirely. This PR is
the step that gets `{{DEJA_SOCK}}` into the script, which #84 builds on.

## Verification

`go test -race ./...` and `go vet ./...` clean. Measured on an Apple Silicon Mac.

