### PR TITLE
build: strip and trim source builds to match releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ For anything larger than a small bug fix or doc tweak, please **open an issue fi
 ```bash
 git clone https://github.com/Giammarco-Ferranti/deja.git
 cd deja
-make build        # produces ./bin/deja
+make build        # produces ./bin/deja, stripped and trimmed like a release
+make build-debug  # same path, unstripped, for delve
 
 go test ./...     # run all tests
 go test -race ./... # what CI runs

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
-.PHONY: build test test-cover vet install clean
+.PHONY: build build-debug test test-cover vet install clean
+
+# Match .goreleaser.yaml so a source build is the same size as a released one.
+# Without these, `go build` retains the symbol table and DWARF — 12.4 MB against
+# the 7.5 MB that actually ships. `-trimpath` additionally keeps local absolute
+# paths out of the binary.
+RELEASE_FLAGS := -trimpath -ldflags="-s -w"
 
 build:
-	go build ./cmd/deja
+	go build $(RELEASE_FLAGS) -o bin/deja ./cmd/deja
+
+# Unstripped, DWARF intact, for delve and friends.
+build-debug:
+	go build -o bin/deja ./cmd/deja
 
 test:
 	go test -race ./...
@@ -14,7 +24,8 @@ vet:
 	go vet ./...
 
 install:
-	go install ./cmd/deja
+	go install $(RELEASE_FLAGS) ./cmd/deja
 
 clean:
+	rm -rf bin
 	rm -f deja

--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,16 @@ module github.com/giammarcoferranti/deja
 
 go 1.25.2
 
-require github.com/sahilm/fuzzy v0.1.1
+require (
+	github.com/sahilm/fuzzy v0.1.1
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.31.1
+)
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.42 // indirect
 	golang.org/x/text v0.36.0 // indirect
-	gorm.io/driver/sqlite v1.6.0 // indirect
-	gorm.io/gorm v1.31.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=


### PR DESCRIPTION
## Why

`.goreleaser.yaml` already passes `-trimpath` and `-s -w`, so **every shipped binary is
7.1 MiB**. The `Makefile` passed no ldflags at all:

| Build | Size |
|---|---|
| `make build` / `make install` (before) | **11.8 MiB** |
| `.goreleaser.yaml`, i.e. what ships | **7.1 MiB** |
| `make build` (after) | **7.1 MiB** |

So the "deja is 12 MB" figure was an unstripped local dev build, not a dependency
problem. Anyone building from source paid a 40% penalty for a symbol table and DWARF they
didn't ask for.

## What

- `build` and `install` now pass `-trimpath -ldflags="-s -w"`, matching goreleaser exactly.
  `-trimpath` also keeps local absolute paths out of the binary.
- New `build-debug` target without the flags, so DWARF stays available for delve.
- `build` writes to `bin/deja` — which `README.md:326` and `CONTRIBUTING.md` already
  documented and `.gitignore` already anticipated with its `bin/` entry, while the Makefile
  was actually dropping the binary in the repo root. `clean` follows it there and still
  removes a stray root `deja` from older builds.
- `go mod tidy`: drops `github.com/google/uuid` (absent from `go list -deps ./cmd/deja`,
  so nothing in the build graph has referenced it for some time) and promotes `gorm.io/*`
  to direct requires, which is what they are.

## Verification

```
$ make build      && ls -l bin/deja   # 7,479,874 bytes  (7.13 MiB)
$ make build-debug && ls -l bin/deja  # 12,377,026 bytes (11.80 MiB)
$ nm bin/deja                          # 3 undefined symbols stripped vs 14134 unstripped
```

`go test -race ./...` and `go vet ./...` clean. No functional change — build plumbing only.

