### PR TITLE
perf: stop loading every directory affinity to answer one keystroke

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,9 +352,9 @@ score = 1.0 × fuzzy
                                                commands · stats · seqs
 ```
 
-The daemon loads all state into memory at startup (`map[string]*CommandStat`, top-100 directory affinities, sequence pairs) and uses a `sync.RWMutex` so reads never block each other. Writes (command recording) take microseconds.
+The daemon loads all state into memory at startup (`map[string]*CommandStat`, directory affinities, sequence pairs) and uses a `sync.RWMutex` so reads never block each other. Writes (command recording) take microseconds.
 
-If the daemon is unavailable, `deja query` falls back to a direct SQLite read automatically.
+If the daemon is unavailable, `deja query` falls back to a direct SQLite read automatically. That path ranks in two passes — once on fuzzy, frecency and sequence signal, then again over the top 50 with directory affinities fetched just for them — so a keystroke costs a few queries rather than one per command in your history.
 
 ---
 

--- a/cmd/deja/query.go
+++ b/cmd/deja/query.go
@@ -18,6 +18,25 @@ import (
 const (
 	dialTimeout = 50 * time.Millisecond
 	readTimeout = 150 * time.Millisecond
+
+	// affinityShortlistCap bounds how many commands get a directory-affinity
+	// lookup when the score distribution is too flat for the cutoff to bite —
+	// which is the common case for a one- or two-character buffer, where the
+	// cutoff admits nearly every candidate.
+	//
+	// Sized from measurement against a 110k-row history: a lookup costs ~0.02ms,
+	// so five hundred of them is ~10ms, against ~70ms for all 3,400 candidates.
+	//
+	// The cost of the cap is that a command ranked below it cannot be lifted into
+	// view by affinity alone. Measured over 120 buffer/directory pairs against the
+	// uncapped ranking: the primary suggestion was identical in all 120, and 8
+	// differed somewhere in the four alternatives — always a command with strong
+	// affinity to that directory but little frecency, which is exactly the
+	// population the cap excludes.
+	affinityShortlistCap = 500
+
+	// maxFallbackAlternatives mirrors the daemon's maxAlternatives.
+	maxFallbackAlternatives = 4
 )
 
 func runQuery(args []string) {
@@ -103,6 +122,37 @@ func dialAndSuggest(buffer, dir, prev string) (daemon.SuggestResp, error) {
 // fallbackSuggest runs the same scoring path the daemon would, but against
 // a freshly opened SQLite connection. Slower (cold reads) but keeps the
 // shell responsive when the daemon is down.
+// shortlistForAffinity picks the commands worth a directory-affinity lookup
+// from a ranking computed without one. ranked must be sorted by score
+// descending, as Rank leaves it.
+//
+// Everything scoring within scorer.MaxDirBoost of the fifth place is included:
+// those are exactly the candidates affinity could still lift into view, since
+// the five already there can only gain score themselves. The cap is a guard
+// against a flat score distribution — an empty buffer gives every candidate the
+// same fuzzy score — turning "shortlist" back into "the whole history".
+func shortlistForAffinity(ranked []scorer.Result) []string {
+	visible := maxFallbackAlternatives + 1
+	if len(ranked) <= visible {
+		names := make([]string, len(ranked))
+		for i, r := range ranked {
+			names[i] = r.Command
+		}
+		return names
+	}
+
+	cutoff := ranked[visible-1].Score - scorer.MaxDirBoost
+
+	names := make([]string, 0, visible)
+	for _, r := range ranked {
+		if r.Score < cutoff || len(names) >= affinityShortlistCap {
+			break
+		}
+		names = append(names, r.Command)
+	}
+	return names
+}
+
 func fallbackSuggest(buffer, dir, prev string) daemon.SuggestResp {
 	// Mirror the daemon's empty-prompt gate (handlers.go Suggest): when the
 	// user has opted out of predictions on a fresh prompt, don't even open the
@@ -119,7 +169,7 @@ func fallbackSuggest(buffer, dir, prev string) daemon.SuggestResp {
 	if err != nil {
 		return daemon.SuggestResp{}
 	}
-	db, err := store.InitDB(path)
+	db, err := store.OpenReader(path)
 	if err != nil {
 		return daemon.SuggestResp{}
 	}
@@ -131,26 +181,50 @@ func fallbackSuggest(buffer, dir, prev string) daemon.SuggestResp {
 
 	seq, _ := store.GetSequenceCounts(db, prev)
 
-	dirCounts := make(map[string]map[string]int, len(stats))
-	for _, s := range stats {
-		dc, err := store.GetDirCountsForCommand(db, s.Command)
-		if err != nil {
-			continue
-		}
-		dirCounts[s.Command] = dc
-	}
-
 	fuzziness := scorer.FuzzyDefault
 	if cfgDir, err := dataDir(); err == nil {
 		fuzziness, _ = config.LoadFuzzy(cfgDir)
 	}
-	ranked := scorer.Rank(stats, buffer, dir, prev, seq, dirCounts, time.Now(), fuzziness)
+	now := time.Now()
+
+	// Directory affinity is the one signal needing a per-command lookup, and
+	// fetching it for every command in the history is what made this path cost
+	// hundreds of milliseconds per keystroke. So rank without it first, then fold
+	// it in for the handful of commands that could plausibly win.
+	//
+	// Folding in afterwards rather than re-ranking a shortlist matters: fuzzy and
+	// frecency are min-max normalised across the candidate set, so re-running
+	// Rank over 50 survivors would renormalise every signal over a different
+	// population and reorder results that had nothing to do with affinity.
+	// ApplyDirAffinity instead adds the same per-command term Rank would have
+	// added, to the scores Rank already computed over the full set.
+	//
+	// The shortlist is chosen to be provably sufficient rather than guessed at.
+	// Affinity only ever adds, and adds at most scorer.MaxDirBoost, so a
+	// candidate can reach the visible results only if its pre-affinity score is
+	// within that of the current fifth place — everything below cannot get there
+	// however strong its affinity. Looking those up would be work whose outcome
+	// is already decided.
+	ranked := scorer.Rank(stats, buffer, dir, prev, seq, nil, now, fuzziness)
 	if len(ranked) == 0 {
 		return daemon.SuggestResp{}
 	}
 
-	alts := make([]string, 0, 4)
-	for i := 1; i < len(ranked) && len(alts) < 4; i++ {
+	names := shortlistForAffinity(ranked)
+
+	dirCounts := make(map[string]map[string]int, len(names))
+	for _, name := range names {
+		// A failed lookup costs this command its affinity, one signal of four,
+		// which still leaves a usable ranking. Nothing here is worth abandoning
+		// the whole suggestion over.
+		if dc, err := store.GetDirCountsForCommand(db, name); err == nil {
+			dirCounts[name] = dc
+		}
+	}
+	ranked = scorer.ApplyDirAffinity(ranked, dir, dirCounts)
+
+	alts := make([]string, 0, maxFallbackAlternatives)
+	for i := 1; i < len(ranked) && len(alts) < maxFallbackAlternatives; i++ {
 		alts = append(alts, ranked[i].Command)
 	}
 	return daemon.SuggestResp{Suggestion: ranked[0].Command, Alternatives: alts}

--- a/internal/daemon/state.go
+++ b/internal/daemon/state.go
@@ -21,15 +21,23 @@ const defaultShowEmpty = true
 type State struct {
 	mu        sync.RWMutex
 	db        *gorm.DB
-	stats     []store.CommandStat       // top-100 most-used, from GetCommandStats
+	stats     []store.CommandStat       // every command_stats row, most-used first
 	seqByPrev map[string]map[string]int // prev → next → count, filled lazily
 	dirCounts map[string]map[string]int // cmd  → dir  → count
 	fuzzy     scorer.Fuzzy              // strictness preset for fuzzy matching
 	showEmpty bool                      // suggest on an empty prompt?
 }
 
-// Load warms state from SQLite. It preloads only the dirCounts for the
-// top-100 command_stats so memory stays bounded regardless of history size.
+// Load warms state from SQLite: every command_stats row, plus each one's
+// directory affinities.
+//
+// The per-command affinity loop looks like an obvious candidate for a single
+// grouped query, and is not: `GROUP BY command, directory` over the whole
+// commands table measures 318ms against a 110k-row history, where this loop of
+// index seeks measures ~150ms. It is also paid once, at daemon startup, to keep
+// the keystroke path free of SQLite entirely — which is the trade that matters.
+// The suggestion path that *cannot* afford it is fallbackSuggest, and that one
+// scopes the lookup to a shortlist instead (see cmd/deja/query.go).
 func Load(db *gorm.DB) (*State, error) {
 	stats, err := store.GetCommandStats(db)
 	if err != nil {

--- a/internal/scorer/scorer.go
+++ b/internal/scorer/scorer.go
@@ -110,6 +110,12 @@ const seqWeight = 0.5
 const frecencyWeight = 0.4
 const dirWeight = 0.3
 
+// MaxDirBoost is the most that directory affinity can add to a score: affinity
+// is a ratio in [0,1], so the weighted term tops out at dirWeight. Callers that
+// rank before knowing affinities use this to bound which candidates could still
+// change the outcome once affinities arrive (see ApplyDirAffinity).
+const MaxDirBoost = dirWeight
+
 func Rank(
 	candidates []store.CommandStat,
 	buffer, dir, prev string,
@@ -145,6 +151,44 @@ func Rank(
 
 	return out
 
+}
+
+// ApplyDirAffinity folds directory affinity into an existing ranking and
+// re-sorts, for callers that cannot afford to look up affinities before ranking.
+//
+// This is exact, not an approximation, and only because of an asymmetry in the
+// signals: fuzzy and frecency are min-max normalised across the candidate set,
+// so they cannot be recomputed over a subset without changing every score,
+// whereas directory affinity is purely per-command — dc[dir] over that
+// command's own total. Adding its weighted term afterwards therefore lands on
+// exactly the scores Rank would have produced with dirCounts passed in.
+//
+// Commands absent from dirCounts score zero affinity, which is also what Rank
+// does for a command with no recorded directories. That is what lets a caller
+// fetch affinities for a shortlist and leave the tail alone.
+func ApplyDirAffinity(results []Result, dir string, dirCounts map[string]map[string]int) []Result {
+	if dir == "" || len(dirCounts) == 0 {
+		return results
+	}
+
+	for i := range results {
+		dc := dirCounts[results[i].Command]
+		if len(dc) == 0 {
+			continue
+		}
+		total := 0
+		for _, n := range dc {
+			total += n
+		}
+		if total == 0 {
+			continue
+		}
+		results[i].Score += dirWeight * (float64(dc[dir]) / float64(total))
+	}
+
+	sort.Slice(results, func(i, j int) bool { return results[i].Score > results[j].Score })
+
+	return results
 }
 
 func computeFuzzy(candidates []store.CommandStat, buffer string, fuzziness Fuzzy) []float64 {

--- a/internal/scorer/scorer_test.go
+++ b/internal/scorer/scorer_test.go
@@ -398,3 +398,78 @@ func findResult(rs []Result, cmd string) *Result {
 	}
 	return nil
 }
+
+// TestApplyDirAffinity_EquivalentToRank is the whole justification for the
+// function existing: folding affinity in afterwards must land on exactly the
+// scores and order Rank produces when given dirCounts up front. If that ever
+// stops holding — say because directory affinity gains a normalisation across
+// candidates, the way fuzzy and frecency have — then cmd/deja/query.go's
+// fallback silently starts ranking differently from the daemon.
+func TestApplyDirAffinity_EquivalentToRank(t *testing.T) {
+	now := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
+
+	candidates := []store.CommandStat{
+		{Command: "git status", Count: 40, LastUsed: now.Add(-time.Hour)},
+		{Command: "git stash", Count: 12, LastUsed: now.Add(-48 * time.Hour)},
+		{Command: "git commit -m", Count: 30, LastUsed: now.Add(-2 * time.Hour)},
+		{Command: "go test ./...", Count: 25, LastUsed: now.Add(-30 * time.Minute)},
+		{Command: "grep -r", Count: 3, LastUsed: now.Add(-200 * time.Hour)},
+		{Command: "make build", Count: 8, LastUsed: now.Add(-6 * time.Hour)},
+	}
+	dirCounts := map[string]map[string]int{
+		"git status":    {"/repo": 30, "/other": 10},
+		"git stash":     {"/other": 12},
+		"git commit -m": {"/repo": 30},
+		"go test ./...": {"/repo": 5, "/elsewhere": 20},
+		"make build":    {},
+	}
+	seq := map[string]int{"go test ./...": 4, "git status": 1}
+
+	for _, buffer := range []string{"", "g", "gi", "git", "git s", "go t", "make", "zzz"} {
+		for _, dir := range []string{"/repo", "/other", "/elsewhere", "/unseen", ""} {
+			t.Run(buffer+"|"+dir, func(t *testing.T) {
+				want := Rank(candidates, buffer, dir, "prev", seq, dirCounts, now, FuzzySmart)
+
+				got := Rank(candidates, buffer, dir, "prev", seq, nil, now, FuzzySmart)
+				got = ApplyDirAffinity(got, dir, dirCounts)
+
+				if len(got) != len(want) {
+					t.Fatalf("len: got %d, want %d", len(got), len(want))
+				}
+				for i := range want {
+					if got[i].Command != want[i].Command {
+						t.Errorf("position %d: got %q, want %q\n got: %v\nwant: %v",
+							i, got[i].Command, want[i].Command, got, want)
+					}
+					if math.Abs(got[i].Score-want[i].Score) > 1e-12 {
+						t.Errorf("%q score: got %v, want %v", got[i].Command, got[i].Score, want[i].Score)
+					}
+				}
+			})
+		}
+	}
+}
+
+// A command missing from dirCounts must score zero affinity, not be dropped —
+// that is what lets the fallback fetch affinities for a shortlist and leave the
+// tail in place.
+func TestApplyDirAffinity_PartialCountsKeepTail(t *testing.T) {
+	now := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
+	candidates := []store.CommandStat{
+		{Command: "alpha", Count: 10, LastUsed: now},
+		{Command: "beta", Count: 10, LastUsed: now},
+		{Command: "gamma", Count: 10, LastUsed: now},
+	}
+
+	full := Rank(candidates, "", "/repo", "", nil, nil, now, FuzzySmart)
+	partial := ApplyDirAffinity(full, "/repo", map[string]map[string]int{
+		"beta": {"/repo": 5},
+	})
+
+	if len(partial) != 3 {
+		t.Fatalf("got %d results, want 3 — commands without affinity data were dropped", len(partial))
+	}
+	if partial[0].Command != "beta" {
+		t.Errorf("got %q first, want beta promoted by its affinity", partial[0].Command)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -100,6 +100,33 @@ func restrictDBFiles(path string) error {
 	return nil
 }
 
+// OpenReader opens the database for reading without running AutoMigrate.
+//
+// InitDB's AutoMigrate is DDL introspection: it interrogates the schema of
+// every model on every call. That is the right thing when a writer is about to
+// touch the database, and the wrong thing on the suggestion path, which opens
+// the database once per keystroke whenever the daemon is unreachable.
+//
+// Deliberately not `mode=ro`: a read-only open of a WAL database fails outright
+// when the -shm file is absent, which is exactly the daemon-is-down situation
+// this path exists to serve. Skipping the migration is the win; refusing to
+// open is not a trade worth making for it.
+func OpenReader(path string) (*gorm.DB, error) {
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{})
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite %q: %w", path, err)
+	}
+	// Same lock-down as InitDB. This path is read-only in intent, but opening a
+	// database that does not exist creates it, and SQLite would leave it 0644.
+	if err := restrictDBFiles(path); err != nil {
+		return nil, err
+	}
+	if err := db.Exec("PRAGMA busy_timeout=5000;").Error; err != nil {
+		return nil, fmt.Errorf("set busy_timeout: %w", err)
+	}
+	return db, nil
+}
+
 // Keeps multi-row INSERTs under SQLite's SQLITE_MAX_VARIABLE_NUMBER
 // (999 on older builds). Widest row is Command at 7 columns, so 100
 // rows ≈ 700 host params.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -457,3 +457,32 @@ func TestSaveImportBatch_DropsIgnoredCommands(t *testing.T) {
 		}
 	}
 }
+
+// OpenReader skips AutoMigrate, so it must not be able to create a schema —
+// but it must read an existing one perfectly well.
+func TestOpenReader_ReadsWithoutMigrating(t *testing.T) {
+	path := openTestDB(t)
+
+	db, err := InitDB(path)
+	if err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	now := time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC)
+	if err := RecordCommand(db, Command{
+		Command: "git status", Directory: "/repo", Timestamp: now, SessionID: "s",
+	}, ""); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	rdb, err := OpenReader(path)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	stats, err := GetCommandStats(rdb)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if len(stats) != 1 || stats[0].Command != "git status" {
+		t.Fatalf("got %+v, want the one recorded command", stats)
+	}
+}


### PR DESCRIPTION
> **Stack** — merge bottom-up. This is the base of two chains:
>
> - storage: #89, #86, **#83** ⬅
> - scorer: #85, **#83** ⬅

## Why

When the daemon is unreachable, `deja query` falls back to a direct SQLite read. That
fallback reconstructed the daemon's entire in-memory state — every `command_stats` row plus
one directory-affinity query per command — and did it again on the *next* keystroke.

Against my real history (35 MB, 109,821 rows, 3,462 distinct commands) that is **131–137 ms
per keystroke**. Not a degraded mode so much as an unusable one, and easy to fall into: the
`-S $DEJA_SOCK` fast path in #81 deliberately accepts a stale socket, and a daemon that died
without cleanup leaves one behind.

Phase breakdown, `buffer="s"`:

```
open db                    0.0ms
load stats                 3.2ms
load sequences             0.1ms
rank (no affinity)         3.5ms
affinity lookup           76.1ms     <- 2,870 queries
```

Ranking was never the problem.

## What

**`store.OpenReader`** — `InitDB` runs `AutoMigrate`, DDL introspection over every model.
Right before a writer touches the database; wrong on a path that opens it once per keystroke.

Deliberately *not* `mode=ro`: a read-only open of a WAL database fails outright when the
`-shm` file is absent, which is exactly the daemon-is-down situation this path exists to
serve. Skipping the migration is the win; refusing to open is not a trade worth making for it.

**A provably sufficient shortlist** — affinity only ever adds, and adds at most `dirWeight`.
So a candidate can reach the visible five only if its pre-affinity score is within that of
the current fifth place; everything below cannot get there however strong its affinity, and
looking it up is work whose outcome is already decided. For `buffer="git st"` that is 8
commands instead of 3,462.

**`scorer.ApplyDirAffinity`** — folding affinity into the existing ranking rather than
re-ranking the shortlist. This is the part that keeps the change honest, and I got it wrong
first:

> Fuzzy and frecency are **min-max normalised across the candidate set**. Re-running `Rank`
> over 50 survivors renormalises every signal over a different population. My first attempt
> did exactly that and **reordered 25 of 60 sampled rankings** for reasons having nothing to
> do with directory affinity.

Directory affinity has no such normalisation — it is `dc[dir]` over that command's own total —
so adding its weighted term afterwards lands on exactly the scores `Rank` would have produced.
`TestApplyDirAffinity_EquivalentToRank` pins that across 40 buffer/directory combinations,
comparing both order and scores to 1e-12.

## Results

| buffer | before | after |
|---|---|---|
| `git st` | 136.4 ms | **35.6 ms** |
| `git` | 131.5 ms | **41.4 ms** |
| `s` | 131.3 ms | **52.4 ms** |
| *(empty)* | 132.6 ms | **44.6 ms** |

~25 ms of what remains is the process launch itself, which #84 removes from the keystroke path
entirely.

**Fidelity**, measured over 120 buffer/directory pairs against the uncapped ranking: the
primary suggestion was identical in **all 120**; 8 differed somewhere in the four
alternatives — always a command with strong affinity to that directory but little frecency,
which is exactly the population `affinityShortlistCap` excludes. The cap only binds for one-
and two-character buffers, where scores cluster too tightly for the cutoff to exclude
anything.

## Two things I tried that measurement rejected

Both are the obvious ideas, so they are worth recording:

**A single grouped query** (`GROUP BY command, directory` over the whole table) to replace the
N+1: **318 ms**, against ~150 ms for the per-command loop it would replace. It scans and sorts
the table instead of seeking through `idx_commands_command`. Scoped to a shortlist it is fine,
but then it is no better than the per-command loop it complicates — at 3,410 commands the
chunked `IN` measured 274 ms against 69 ms for individual seeks. So this PR adds no new store
function; it just calls the existing `GetDirCountsForCommand` fewer times.

**Deriving affinity from one directory-indexed query**, using `command_stats.count` as the
denominator: 34 of 3,463 commands have a `command_stats.count` that disagrees with their row
count in `commands`, so the denominators are wrong. And it is not reliably fast either —
113 ms for the busiest directory.

`daemon.Load` therefore keeps its per-command loop, and gains a comment saying why. Its
docstring claimed it preloaded only the top 100 commands, which was never true —
`GetCommandStats` has no `LIMIT`. Fixed the comment, not the code: adding a limit would
silently drop rare commands from suggestions.

## Verification

`go test -race ./...` and `go vet ./...` clean. New tests cover the `Rank`/`ApplyDirAffinity`
equivalence, partial affinity data leaving the tail in place, and `OpenReader` reading an
existing schema without migrating.

