### PR TITLE
perf: stop scoring signals for candidates the buffer already excluded

### DIFF
--- a/internal/scorer/bench_test.go
+++ b/internal/scorer/bench_test.go
@@ -1,0 +1,87 @@
+package scorer
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/giammarcoferranti/deja/internal/store"
+)
+
+// realisticCandidates builds a candidate set shaped like a real shell history
+// rather than like uniform random strings, because the scorer's cost is driven
+// by total text length and by how many candidates survive fuzzy matching.
+//
+// Proportions are sampled from a 3,463-command history: ~9% one-word commands,
+// ~26% short, ~41% medium, ~24% long, and a single very large outlier (a 17 KB
+// pasted command, which is the kind of thing that actually lands in a history
+// file). Roughly one directory per command.
+func realisticCandidates(n int) ([]store.CommandStat, map[string]map[string]int) {
+	r := rand.New(rand.NewSource(1))
+	now := time.Now()
+
+	verbs := []string{"git", "go", "kubectl", "docker", "make", "brew", "rg", "vim", "cd", "ls", "npm", "cargo", "ssh", "curl"}
+	tail := []string{
+		"status", "commit -m 'fix the thing'", "build ./cmd/deja", "test -race ./...",
+		"get pods -n production --context staging", "compose up -d --build",
+		"install --cask some-application", "--hidden --glob '!vendor' pattern",
+		"internal/scorer/scorer.go", "-la --color=auto", "run build -- --watch",
+	}
+
+	out := make([]store.CommandStat, 0, n)
+	dirs := map[string]map[string]int{}
+	dirNames := []string{"/Users/x/dev/project", "/Users/x", "/tmp", "/Users/x/dev/other"}
+
+	for i := 0; i < n; i++ {
+		var cmd string
+		switch bucket := r.Intn(100); {
+		case bucket < 9:
+			cmd = fmt.Sprintf("%s%d", verbs[r.Intn(len(verbs))], i)
+		case bucket < 35:
+			cmd = fmt.Sprintf("%s %s%d", verbs[r.Intn(len(verbs))], tail[r.Intn(3)], i)
+		case bucket < 76:
+			cmd = fmt.Sprintf("%s %s %s%d", verbs[r.Intn(len(verbs))], tail[r.Intn(len(tail))], tail[r.Intn(len(tail))], i)
+		default:
+			cmd = fmt.Sprintf("%s %s %s %s --flag-%d=%x",
+				verbs[r.Intn(len(verbs))], tail[r.Intn(len(tail))], tail[r.Intn(len(tail))],
+				tail[r.Intn(len(tail))], i, r.Int63())
+		}
+
+		out = append(out, store.CommandStat{
+			Command:  cmd,
+			Count:    r.Intn(500) + 1,
+			LastUsed: now.Add(-time.Duration(r.Intn(1000)) * time.Hour),
+		})
+		dirs[cmd] = map[string]int{dirNames[r.Intn(len(dirNames))]: r.Intn(20) + 1}
+	}
+
+	// One pathological entry. A single pasted heredoc or base64 blob in the
+	// history makes every keystroke scan it, and histories really do contain one.
+	huge := "echo " + strings.Repeat("abcdefghij", 1730)
+	out = append(out, store.CommandStat{Command: huge, Count: 1, LastUsed: now.Add(-500 * time.Hour)})
+	dirs[huge] = map[string]int{"/tmp": 1}
+
+	return out, dirs
+}
+
+func benchRank(b *testing.B, n int, buffer string) {
+	candidates, dirCounts := realisticCandidates(n)
+	seq := map[string]int{candidates[0].Command: 5, candidates[1].Command: 2}
+	now := time.Now()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Rank(candidates, buffer, "/Users/x/dev/project", "ls", seq, dirCounts, now, FuzzySmart)
+	}
+}
+
+// Buffer length is the dimension that matters: a one-character buffer matches
+// almost everything and leaves the most work to do.
+func BenchmarkRank_3500_empty(b *testing.B)  { benchRank(b, 3500, "") }
+func BenchmarkRank_3500_1char(b *testing.B)  { benchRank(b, 3500, "g") }
+func BenchmarkRank_3500_3char(b *testing.B)  { benchRank(b, 3500, "git") }
+func BenchmarkRank_3500_6char(b *testing.B)  { benchRank(b, 3500, "git st") }
+func BenchmarkRank_20000_3char(b *testing.B) { benchRank(b, 20000, "git") }

--- a/internal/scorer/scorer.go
+++ b/internal/scorer/scorer.go
@@ -129,12 +129,27 @@ func Rank(
 		return nil
 	}
 
-	fuzzyScores := computeFuzzy(candidates, buffer, fuzziness)
-	frecencyScores := computeFrecency(candidates, now)
-	dirScores := computeDirAffinity(candidates, dir, dirCounts)
-	seqScores := computeSequence(candidates, seqCounts)
+	fuzzyScores, matched := computeFuzzy(candidates, buffer, fuzziness)
 
-	out := make([]Result, 0, n)
+	// Frecency stays a full pass because it is normalised by the maximum across
+	// every candidate, matched or not — the divisor cannot be known without
+	// visiting all of them. Sequence and directory affinity have no such
+	// dependency: each is a function of one command alone (sequence divides by a
+	// maximum taken over seqCounts, not over candidates). So they are computed
+	// inline, only for candidates that survived the fuzzy filter, which for a
+	// six-character buffer is single digits out of thousands.
+	frecencyScores := computeFrecency(candidates, now)
+	seqMax := 0
+	for _, n := range seqCounts {
+		if n > seqMax {
+			seqMax = n
+		}
+	}
+
+	// Sized to what will actually survive the fuzzy filter. Reserving room for
+	// every candidate costs 84KB a call at this history size to hold, typically,
+	// a few dozen results.
+	out := make([]Result, 0, matched)
 
 	for i, c := range candidates {
 		// Skip candidates that don't match the buffer at all.
@@ -142,7 +157,13 @@ func Rank(
 			continue
 		}
 
-		final := fuzzyWeight*fuzzyScores[i] + seqWeight*seqScores[i] + frecencyWeight*frecencyScores[i] + dirWeight*dirScores[i]
+		final := fuzzyWeight*fuzzyScores[i] + frecencyWeight*frecencyScores[i]
+		if seqMax > 0 {
+			if n, ok := seqCounts[c.Command]; ok {
+				final += seqWeight * (float64(n) / float64(seqMax))
+			}
+		}
+		final += dirWeight * dirAffinity(c.Command, dir, dirCounts)
 
 		out = append(out, Result{Command: c.Command, Score: final})
 	}
@@ -172,18 +193,7 @@ func ApplyDirAffinity(results []Result, dir string, dirCounts map[string]map[str
 	}
 
 	for i := range results {
-		dc := dirCounts[results[i].Command]
-		if len(dc) == 0 {
-			continue
-		}
-		total := 0
-		for _, n := range dc {
-			total += n
-		}
-		if total == 0 {
-			continue
-		}
-		results[i].Score += dirWeight * (float64(dc[dir]) / float64(total))
+		results[i].Score += dirWeight * dirAffinity(results[i].Command, dir, dirCounts)
 	}
 
 	sort.Slice(results, func(i, j int) bool { return results[i].Score > results[j].Score })
@@ -191,24 +201,33 @@ func ApplyDirAffinity(results []Result, dir string, dirCounts map[string]map[str
 	return results
 }
 
-func computeFuzzy(candidates []store.CommandStat, buffer string, fuzziness Fuzzy) []float64 {
+// candidateSource lets the fuzzy matcher read commands straight out of the
+// candidate slice, implementing fuzzy.Source.
+type candidateSource []store.CommandStat
+
+func (c candidateSource) String(i int) string { return c[i].Command }
+func (c candidateSource) Len() int            { return len(c) }
+
+// computeFuzzy returns the per-candidate fuzzy score and how many candidates
+// scored above zero, so the caller can size its result slice to the survivors
+// rather than to the whole history.
+func computeFuzzy(candidates []store.CommandStat, buffer string, fuzziness Fuzzy) ([]float64, int) {
 	scores := make([]float64, len(candidates))
 
 	if buffer == "" {
 		for i := range scores {
 			scores[i] = 1
 		}
-		return scores
+		return scores, len(candidates)
 	}
 
-	list := make([]string, len(candidates))
-	for i, c := range candidates {
-		list[i] = c.Command
-	}
-
-	matches := fuzzy.Find(buffer, list)
+	// FindFrom reads commands in place; fuzzy.Find would need a []string copy of
+	// the entire history built fresh on every keystroke. NoSort because the
+	// library's ordering is by its own match score, which we then throw away —
+	// every match is rescored below and re-sorted by the composite.
+	matches := fuzzy.FindFromNoSort(buffer, candidateSource(candidates))
 	if len(matches) == 0 {
-		return scores
+		return scores, 0
 	}
 
 	// Drop matches whose typed letters are spread further apart than the
@@ -241,14 +260,16 @@ func computeFuzzy(candidates []store.CommandStat, buffer string, fuzziness Fuzzy
 	}
 	if first {
 		// Every match was filtered out by the gap cap.
-		return scores
+		return scores, 0
 	}
 
 	span := max - min
+	survivors := 0
 	for i := range raw {
 		if !matched[i] {
 			continue
 		}
+		survivors++
 		if span == 0 {
 			scores[i] = 1
 		} else {
@@ -261,7 +282,7 @@ func computeFuzzy(candidates []store.CommandStat, buffer string, fuzziness Fuzzy
 		}
 	}
 
-	return scores
+	return scores, survivors
 }
 
 func computeFrecency(candidates []store.CommandStat, now time.Time) []float64 {
@@ -291,54 +312,25 @@ func computeFrecency(candidates []store.CommandStat, now time.Time) []float64 {
 	return raw
 }
 
-func computeDirAffinity(candidates []store.CommandStat, dir string, dirCounts map[string]map[string]int) []float64 {
-	scores := make([]float64, len(candidates))
-
+// dirAffinity is the share of a command's recorded runs that happened in dir.
+// Per-command by construction: no normalisation across candidates, which is
+// what lets both Rank and ApplyDirAffinity add it independently.
+func dirAffinity(command, dir string, dirCounts map[string]map[string]int) float64 {
 	if dir == "" {
-		return scores
+		return 0
 	}
-
-	for i, c := range candidates {
-		dc := dirCounts[c.Command]
-		if len(dc) == 0 {
-			continue
-		}
-
-		total := 0
-		for _, n := range dc {
-			total += n
-		}
-
-		if total == 0 {
-			continue
-		}
-		scores[i] = float64(dc[dir]) / float64(total)
+	dc := dirCounts[command]
+	if len(dc) == 0 {
+		return 0
 	}
-
-	return scores
-}
-
-func computeSequence(candidates []store.CommandStat, seqCounts map[string]int) []float64 {
-	scores := make([]float64, len(candidates))
-	max := 0
-
-	for _, n := range seqCounts {
-		if n > max {
-			max = n
-		}
+	total := 0
+	for _, n := range dc {
+		total += n
 	}
-
-	if max == 0 {
-		return scores
+	if total == 0 {
+		return 0
 	}
-
-	for i, c := range candidates {
-		if n, ok := seqCounts[c.Command]; ok {
-			scores[i] = float64(n) / float64(max)
-		}
-	}
-
-	return scores
+	return float64(dc[dir]) / float64(total)
 }
 
 // maxConsecutiveGap returns the largest run of unmatched characters between


### PR DESCRIPTION
> **Stack** — merge bottom-up:
>
> - **#85** ⬅
> - #83
>
> Targets `main` because the parent branch lives on my fork and GitHub needs the
> base branch to exist in this repo, so *Files changed* also contains the commits
> below this one. The **Commits** tab separates them.

## Why

With the fork+exec gone from the keystroke path (#84), the daemon's own scoring is what a
keystroke now costs — ~2.9 ms against a 3,462-command history. So it is worth a look.

`Rank` computed four full-length score vectors and *then* discarded every candidate the
buffer did not match. For `buffer="git st"`, that is thousands of map lookups and divisions
to rank about eight survivors.

Profile of the worst case (one-character buffer):

```
     360ms 50.00%  fuzzy.FindFromNoSort
      80ms 11.11%  fuzzy.equalFold
      40ms  5.56%  fuzzy.stringSource.String     <- the []string copy
      40ms  5.56%  sort.partition_func
      10ms  1.39%  scorer.computeSequence
      10ms  1.39%  math.log1p
```

## What

**Sequence and directory affinity move inside the result loop**, evaluated only for
candidates that survived the fuzzy filter. Both are functions of a single command — sequence
divides by a maximum taken over `seqCounts`, not over candidates; affinity divides by that
command's own total — so neither depends on the candidate population and this is exact.

**Frecency deliberately stays a full pass.** It is min-max normalised across every candidate,
matched or not, so the divisor cannot be known without visiting all of them. The profile says
that is fine: `Log1p` + `Exp` are ~1.4% of the time.

> My plan for this PR was to cache the frecency vector behind a 60-second staleness window,
> on the reasoning that a signal with a one-week half-life should not be recomputed per
> keystroke. The profile says that would have bought ~1% and cost an invalidation path. Not
> done.

**The fuzzy matcher reads commands in place** via `fuzzy.Source`, instead of being handed a
`[]string` copy of the whole history built fresh on every keystroke. And `FindFromNoSort`:
the library sorted every match by its own score, which `Rank` immediately threw away and
re-sorted by the composite.

**`computeFuzzy` returns the survivor count**, so the result slice is sized to what will land
in it rather than to the whole history — 84 KB a call at this size.

## Results

| benchmark | before | after | delta | bytes before | bytes after | delta |
|---|---|---|---|---|---|---|
| `buffer=""` | 622 µs | 608 µs | −2.2% | 200 K | 144 K | −28% |
| `buffer="g"` | 2632 µs | 2302 µs | **−12.5%** | 819 K | 683 K | −17% |
| `buffer="git st"` | 2300 µs | 2039 µs | **−11.3%** | 445 K | 247 K | **−45%** |

Medians of 5 runs × 200 iterations.

**Rankings are unchanged** — 120 buffer/directory pairs against a real 3,462-command history
produce byte-identical output.

## The benchmark

Added, because there wasn't one. Shaped like a real history rather than uniform random
strings: the length distribution is sampled from a real 3,463-command history (~9% one-word,
~26% short, ~41% medium, ~24% long), roughly one directory per command, plus **a single 17 KB
entry** — because a real history contains a pasted heredoc or base64 blob, and the matcher
scans every byte of it on every keystroke.

My original synthetic benchmark used uniform ~50-character random strings and reported 1.8 ms
where the real path measured very differently. Shape matters here.

## What I did not do

The remaining ~70% is `fuzzy.FindFromNoSort` scanning the command text, and it is irreducible
without an index over the history (trigram, or first-character bucketing). At ~2 ms per
keystroke, entirely off the typing path via `zle -F`, that structure is not currently worth
it — but the benchmark is now committed, so the decision can be revisited against numbers.

I also tried a character-bitmask prefilter to reject candidates before matching. It helps
most for long selective buffers, which are already cheap, and not at all for one-character
buffers, which are the expensive case. Backwards; dropped.

## Verification

`go test -race ./...` and `go vet ./...` clean.

