### PR TITLE
fix: truncate the write-ahead log so it stops holding a high-water mark

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -528,5 +529,74 @@ func TestRecord_DropsIgnoredPrevCommand(t *testing.T) {
 	// The command that followed it is legitimate and must still be recorded.
 	if findStat(state.stats, "git push") == nil {
 		t.Error("git push was not recorded")
+	}
+}
+
+// TestCheckpointWAL_ShrinksTheLog pins the reason this exists: SQLite's own
+// checkpointing bounds the WAL but never makes the file smaller, so a database
+// keeps whatever high-water mark it ever reached. One observed install held a
+// 28MB WAL against a 35MB database with zero live frames in it.
+func TestCheckpointWAL_ShrinksTheLog(t *testing.T) {
+	dir, err := os.MkdirTemp("", "djwal")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	dbPath := filepath.Join(dir, "deja.db")
+	db, err := store.InitDB(dbPath)
+	if err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	state, err := Load(db)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Write enough to push the WAL well past a trivial size.
+	for i := 0; i < 400; i++ {
+		if err := state.Record(RecordReq{
+			Command:   fmt.Sprintf("command number %d with some padding to take up space", i),
+			Dir:       fmt.Sprintf("/dir/%d", i%10),
+			SessionID: "s",
+			Prev:      fmt.Sprintf("command number %d with some padding to take up space", i-1),
+		}); err != nil {
+			t.Fatalf("record %d: %v", i, err)
+		}
+	}
+
+	walPath := dbPath + "-wal"
+	before, err := os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("stat wal: %v", err)
+	}
+	if before.Size() == 0 {
+		t.Skip("WAL is empty; nothing to shrink on this SQLite build")
+	}
+
+	if err := state.CheckpointWAL(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	after, err := os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("stat wal after: %v", err)
+	}
+	if after.Size() >= before.Size() {
+		t.Errorf("WAL did not shrink: %d -> %d bytes", before.Size(), after.Size())
+	}
+
+	// The data has to survive being moved into the main database.
+	stats, err := store.GetCommandStats(db)
+	if err != nil {
+		t.Fatalf("stats after checkpoint: %v", err)
+	}
+	if len(stats) != 400 {
+		t.Errorf("got %d commands after checkpoint, want 400", len(stats))
+	}
+
+	// And the daemon must still be able to write afterwards.
+	if err := state.Record(RecordReq{Command: "after checkpoint", Dir: "/d", SessionID: "s"}); err != nil {
+		t.Fatalf("record after checkpoint: %v", err)
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -600,3 +600,85 @@ func TestCheckpointWAL_ShrinksTheLog(t *testing.T) {
 		t.Fatalf("record after checkpoint: %v", err)
 	}
 }
+
+// TestCheckpointWAL_ReportsRefusal pins the one outcome CheckpointWAL exists to
+// make visible: a truncation SQLite declined to perform.
+//
+// PRAGMA wal_checkpoint answers with a row — busy|log|checkpointed — rather than
+// an error, and a refusal is busy=1 inside that row. db.Exec discards the row,
+// so "truncated" and "could not truncate" are both a nil error, and
+// checkpointLoop logs nothing either way. That is the silence its own comment
+// promises not to keep: "a checkpoint that fails every time means the WAL grows
+// forever, and silence would hide that."
+//
+// The reader parked on an open snapshot below is what makes SQLite refuse. It
+// is not a contrived state; it is one connection reading while another writes.
+//
+// Slow by construction: InitDB sets busy_timeout=5000, so the checkpoint waits
+// out the full timeout before reporting busy.
+func TestCheckpointWAL_ReportsRefusal(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "deja.db")
+	db, err := store.InitDB(dbPath)
+	if err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	state, err := Load(db)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	for i := 0; i < 400; i++ {
+		if err := state.Record(RecordReq{
+			Command:   fmt.Sprintf("command number %d with some padding to take up space", i),
+			Dir:       fmt.Sprintf("/dir/%d", i%10),
+			SessionID: "s",
+		}); err != nil {
+			t.Fatalf("record %d: %v", i, err)
+		}
+	}
+
+	walPath := dbPath + "-wal"
+	before, err := os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("stat wal: %v", err)
+	}
+	if before.Size() == 0 {
+		t.Fatalf("no WAL to truncate — the premise of this test does not hold on this build")
+	}
+
+	// Hold a read snapshot open across the checkpoint.
+	rdb, err := store.OpenReader(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	sqlDB, err := rdb.DB()
+	if err != nil {
+		t.Fatalf("sql.DB: %v", err)
+	}
+	tx, err := sqlDB.Begin()
+	if err != nil {
+		t.Fatalf("begin read tx: %v", err)
+	}
+	defer tx.Rollback()
+	var n int
+	if err := tx.QueryRow("SELECT count(*) FROM commands").Scan(&n); err != nil {
+		t.Fatalf("read inside tx: %v", err)
+	}
+
+	checkpointErr := state.CheckpointWAL()
+
+	after, err := os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("stat wal after: %v", err)
+	}
+
+	if after.Size() < before.Size() {
+		// SQLite truncated it despite the reader, so there is no refusal to report.
+		return
+	}
+	if checkpointErr == nil {
+		t.Errorf("checkpoint truncated nothing (WAL %d -> %d bytes) but CheckpointWAL returned nil; "+
+			"a refusal has to be observable or checkpointLoop cannot log a WAL that never shrinks",
+			before.Size(), after.Size())
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -15,8 +15,12 @@ import (
 )
 
 const (
-	connDeadline  = 2 * time.Second
-	probeTimeout  = 50 * time.Millisecond
+	connDeadline = 2 * time.Second
+	probeTimeout = 50 * time.Millisecond
+
+	// checkpointInterval is how often the WAL is truncated. See checkpointLoop
+	// for why it is long rather than eager.
+	checkpointInterval = 10 * time.Minute
 )
 
 // PidPath returns the pidfile that accompanies a daemon listening on sockPath.
@@ -69,6 +73,8 @@ func Serve(ctx context.Context, state *State, sockPath string) error {
 		l.Close()
 	}()
 
+	go checkpointLoop(ctx, state)
+
 	defer os.Remove(sockPath)
 
 	for {
@@ -105,6 +111,32 @@ func isLiveSocket(sockPath string, timeout time.Duration) bool {
 		return false
 	}
 	return resp.Pong
+}
+
+// checkpointLoop truncates the write-ahead log periodically, since SQLite's own
+// checkpointing bounds the WAL's size but never reduces it. See State.CheckpointWAL.
+//
+// The interval is long on purpose. Reclaiming disk is not urgent, and a
+// TRUNCATE checkpoint has to wait out readers, so doing it often would trade a
+// real cost against a benefit measured in megabytes per day.
+func checkpointLoop(ctx context.Context, state *State) {
+	t := time.NewTicker(checkpointInterval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			// Busy is the expected outcome when a reader is mid-snapshot, and the
+			// next tick will retry, so it is not worth reporting on its own. Any
+			// error is logged rather than swallowed: a checkpoint that fails every
+			// time means the WAL grows forever, and silence would hide that.
+			if err := state.CheckpointWAL(); err != nil {
+				fmt.Fprintf(os.Stderr, "deja daemon: wal checkpoint: %v\n", err)
+			}
+		}
+	}
 }
 
 func handle(conn net.Conn, state *State) {

--- a/internal/daemon/state.go
+++ b/internal/daemon/state.go
@@ -63,6 +63,24 @@ func Load(db *gorm.DB) (*State, error) {
 	}, nil
 }
 
+// CheckpointWAL moves the write-ahead log into the database and truncates it.
+//
+// SQLite's automatic checkpointing keeps the WAL from growing without bound,
+// but it never makes the file smaller: a PASSIVE checkpoint copies pages into
+// the database and then restarts the WAL from offset zero, reusing the space.
+// So the file keeps whatever high-water mark it ever reached — after `deja
+// import` writes a whole shell history in one transaction, that can be tens of
+// megabytes sitting on disk for the lifetime of the database. One observed
+// install held a 28MB WAL against a 35MB database, with zero live frames in it.
+//
+// TRUNCATE is the only checkpoint mode that shrinks the file. It is also the
+// one that can be refused: it needs every reader to be off the old snapshot,
+// and reports busy rather than waiting. That is fine here — this runs on a
+// timer, so a refusal just means the next tick tries again.
+func (s *State) CheckpointWAL() error {
+	return s.db.Exec("PRAGMA wal_checkpoint(TRUNCATE);").Error
+}
+
 // SetFuzzy updates the strictness preset used by Suggest.
 func (s *State) SetFuzzy(f scorer.Fuzzy) {
 	s.mu.Lock()

--- a/internal/daemon/state.go
+++ b/internal/daemon/state.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/giammarcoferranti/deja/internal/scorer"
@@ -74,11 +75,26 @@ func Load(db *gorm.DB) (*State, error) {
 // install held a 28MB WAL against a 35MB database, with zero live frames in it.
 //
 // TRUNCATE is the only checkpoint mode that shrinks the file. It is also the
-// one that can be refused: it needs every reader to be off the old snapshot,
-// and reports busy rather than waiting. That is fine here — this runs on a
-// timer, so a refusal just means the next tick tries again.
+// one that can be refused: it needs every reader to be off the old snapshot.
+// That is fine here — this runs on a timer, so a refusal just means the next
+// tick tries again.
+//
+// The refusal has to be read out of the result row rather than the error. The
+// pragma answers with busy|log|checkpointed and reports a decline as busy=1,
+// not as a failed statement, so Exec would return nil having shrunk nothing —
+// and a WAL that can never be truncated would look exactly like one that just
+// was. Nor does it return promptly: InitDB sets busy_timeout=5000, so SQLite
+// waits out the timeout first.
 func (s *State) CheckpointWAL() error {
-	return s.db.Exec("PRAGMA wal_checkpoint(TRUNCATE);").Error
+	var busy, logFrames, checkpointed int
+	if err := s.db.Raw("PRAGMA wal_checkpoint(TRUNCATE);").
+		Row().Scan(&busy, &logFrames, &checkpointed); err != nil {
+		return err
+	}
+	if busy != 0 {
+		return fmt.Errorf("refused, %d frames left in the log", logFrames)
+	}
+	return nil
 }
 
 // SetFuzzy updates the strictness preset used by Suggest.


### PR DESCRIPTION
> **Stack** — merge bottom-up:
>
> - #89
> - **#86** ⬅
> - #83
>
> Targets `main` because the parent branch lives on my fork and GitHub needs the
> base branch to exist in this repo, so *Files changed* also contains the commits
> below this one. The **Commits** tab separates them.

## What I found

My install had a **28 MB WAL against a 35 MB database**. I assumed a checkpoint failure. It
is not one.

SQLite's automatic checkpointing bounds the WAL's *contents* fine, but a PASSIVE checkpoint
copies pages into the database and then restarts the log from offset zero — **reusing** the
space rather than releasing it. The file keeps whatever size it ever reached, and `deja
import` writes an entire shell history in one transaction, so the mark it sets is large and
permanent.

Confirmed on a **copy** of that database:

```
$ ls -l deja.db deja.db-wal
35450880  deja.db
28353872  deja.db-wal

$ time sqlite3 deja.db "pragma wal_checkpoint(truncate);"
0|0|0
0.083 total

$ ls -l deja.db deja.db-wal
35467264  deja.db
       0  deja.db-wal

$ sqlite3 deja.db "... ; pragma integrity_check;"
commands|109821   stats|3462   seqs|3612   ok
```

`0|0|0` is `busy|log|checkpointed` — **zero live frames**. The log had nothing in it and was
28 MB anyway. That is the whole finding.

A reproduction on a fresh database shows the same shape from the other side — 4,000 records
through the daemon:

| records | db | wal |
|---|---|---|
| 500 | 192 KB | 4.14 MB |
| 1500 | 503 KB | 4.17 MB |
| 2500 | 806 KB | 4.17 MB |
| 4000 | 1.27 MB | 4.17 MB |

The database grows steadily; the WAL climbs to the 1000-page autocheckpoint threshold and
sits there. Bounded, never smaller.

## What this changes

The daemon truncates the WAL on a ten-minute timer.

TRUNCATE is the only checkpoint mode that shrinks the file, and the only one that can be
refused — it needs every reader off the old snapshot and reports busy rather than waiting.
On a timer that is the right trade: a refusal just means the next tick retries. The interval
is long because reclaiming disk is not urgent and waiting out readers is not free.

Errors are logged rather than swallowed. A checkpoint that fails *every* time means the WAL
really does grow forever, and silence would hide precisely the problem this is here to
prevent.

## Verification

`go test -race ./...` and `go vet ./...` clean.

`TestCheckpointWAL_ShrinksTheLog` writes 400 records, asserts the WAL shrinks, that all 400
commands survive being moved into the main database, and that the daemon can still write
afterwards.

## Out of scope

The `commands` table grows unbounded — 109,821 rows / 35 MB here — so `Load` and the
directory-affinity queries degrade slowly forever. Pruning by age or row cap is a behaviour
change, since it discards history, and wants its own PR once you have decided a retention
policy. Happy to open an issue.

