### PR TITLE
feat: keep the cached init script fresh instead of regenerating it per shell

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -94,8 +94,20 @@ brews:
     caveats: |
       To enable deja in zsh, add the following to your ~/.zshrc:
 
-        eval "$(deja init zsh)"
+        if [[ -r "$HOME/.local/share/deja/init.zsh" ]]; then
+          source "$HOME/.local/share/deja/init.zsh"
+        else
+          eval "$(deja init zsh)"
+        fi
+
+      Sourcing the cached script keeps deja off your shell startup path; the
+      eval is only the first-run bootstrap, and deja refreshes the file itself
+      when you upgrade.
 
       Import your existing zsh history with:
 
         deja import
+
+      Upgrading? The daemon outlives shell sessions, so replace it with:
+
+        deja daemon --restart

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ No account. No sync server. No TUI. Just ghost text that knows where you are.
 ### Homebrew (macOS & Linux)
 
 ```bash
-brew install Giammarco-Ferranti/deja/deja && deja import && (grep -qF 'deja init zsh' ~/.zshrc 2>/dev/null || echo 'eval "$(deja init zsh)"' >> ~/.zshrc) && exec zsh
+brew install Giammarco-Ferranti/deja/deja && deja import && (grep -qF 'deja/init.zsh' ~/.zshrc 2>/dev/null || echo 'if [[ -r "$HOME/.local/share/deja/init.zsh" ]]; then source "$HOME/.local/share/deja/init.zsh"; else eval "$(deja init zsh)"; fi' >> ~/.zshrc) && exec zsh
 ```
 
 ### curl (any Linux/macOS, no Homebrew required)
@@ -57,8 +57,8 @@ Both commands install deja, import your existing zsh history, add the integratio
 If you manage zsh with [Oh My Zsh](https://ohmyz.sh), enable deja the idiomatic way, the same flow as `zsh-autosuggestions`. The binary still comes from Homebrew or the curl script; the plugin just sources deja's integration for you.
 
 ```bash
-# 1. Install the deja binary. Skip (or remove) the `eval "$(deja init zsh)"` line it
-#    offers to add to ~/.zshrc, since the plugin runs that for you:
+# 1. Install the deja binary. Skip (or remove) the activation lines it offers to
+#    add to ~/.zshrc, since the plugin loads the integration for you:
 brew install Giammarco-Ferranti/deja/deja          # or the curl installer above
 
 # 2. Clone the plugin into Oh My Zsh's custom plugins dir:
@@ -81,7 +81,7 @@ zinit ice wait"0" lucid depth=1
 zinit light Giammarco-Ferranti/deja
 ```
 
-zinit handles the Oh My Zsh plugin integration, so the `eval "$(deja init zsh)"` line is not needed. Make sure the `deja` binary is installed separately via Homebrew or the curl installer.
+zinit handles the Oh My Zsh plugin integration, so the activation lines in `~/.zshrc` are not needed. Make sure the `deja` binary is installed separately via Homebrew or the curl installer.
 
 ### Manual (any framework)
 
@@ -94,7 +94,7 @@ curl -fsSL https://raw.githubusercontent.com/Giammarco-Ferranti/deja/main/deja.p
 ```
 
 
-> **Pick one activation, not both.** The plugin runs `eval "$(deja init zsh)"` for you, so if the installer already appended that line to `~/.zshrc`, remove it. Keeping both double-sources the integration.
+> **Pick one activation, not both.** The plugin loads deja's integration for you, so if the installer already appended activation lines to `~/.zshrc`, remove them. Keeping both double-sources the integration.
 >
 > Deja replaces `zsh-autosuggestions`, so don't list both in `plugins=()`. If deja detects `zsh-autosuggestions` is loaded it stands down (see [Troubleshooting](#troubleshooting)).
 
@@ -118,12 +118,30 @@ see it point deja at the file explicitly:
 deja import --file /path/to/history
 ```
 
-To make it permanent, add the `eval` line to your `~/.zshrc`:
+To make it permanent, add this to your `~/.zshrc`:
 
 ```zsh
 # ~/.zshrc
-eval "$(deja init zsh)"
+if [[ -r "$HOME/.local/share/deja/init.zsh" ]]; then
+  source "$HOME/.local/share/deja/init.zsh"
+else
+  eval "$(deja init zsh)"
+fi
 ```
+
+`deja init zsh` does not print the integration script — it *writes* it to
+`~/.local/share/deja/init.zsh` and prints a `source` line for that file. So
+`eval "$(deja init zsh)"` spends a full binary launch, ~25–36 ms on every shell
+you open, regenerating a file that is almost always byte-identical. Sourcing the
+file directly skips that; the `eval` above is only the first-run bootstrap, for
+before the file exists.
+
+Deja keeps the cached script current itself. Each shell compares the installed
+binary's stat identity against the one baked into the script — 0.083 ms, no
+subprocess — and if they differ, regenerates it in the background. The shell
+that noticed carries on with the old script; the next one picks up the new. So
+an upgrade never costs you a slow shell startup, and never leaves you on a stale
+integration either.
 
 Deja auto-spawns its daemon on first use and keeps it running across sessions.
 
@@ -146,7 +164,7 @@ Deja auto-spawns its daemon on first use and keeps it running across sessions.
 
 ### Custom key bindings
 
-Every binding above can be remapped by exporting the matching env var **before** `eval "$(deja init zsh)"` in your `~/.zshrc`. Values are zle key sequences (e.g. `^I` is Tab, `^X` is Ctrl+X, `^[[1;2C` is Shift+→); run `bindkey -L` or pipe a keypress through `cat -v` to discover a key's sequence. Set any var to empty to leave that key unbound.
+Every binding above can be remapped by exporting the matching env var **before** the lines that load deja in your `~/.zshrc`. Values are zle key sequences (e.g. `^I` is Tab, `^X` is Ctrl+X, `^[[1;2C` is Shift+→); run `bindkey -L` or pipe a keypress through `cat -v` to discover a key's sequence. Set any var to empty to leave that key unbound.
 
 ```bash
 # defaults
@@ -284,7 +302,7 @@ Every subcommand supports `--help` (e.g. `deja query --help`) for flag-level det
 
 **Suggestions aren't appearing.**
 1. Check the daemon is reachable: `deja ping` should print `pong`.
-2. Confirm the integration is loaded in your shell: `eval "$(deja init zsh)"` must be in `~/.zshrc` and the shell re-sourced (`exec zsh`).
+2. Confirm the integration is loaded in your shell: `~/.zshrc` must source `~/.local/share/deja/init.zsh` (see [Setup](#setup)) and the shell must have been re-sourced (`exec zsh`).
 3. `Ctrl+X` toggles per-session suppression — start a new shell to clear it.
 
 **Using another inline-suggestion plugin.**
@@ -417,9 +435,13 @@ For how deja handles sensitive commands, and how to keep one out of the database
 
 ## Uninstall
 
-1. Remove the integration line from `~/.zshrc`:
+1. Remove the activation lines from `~/.zshrc` — whichever form you used:
    ```zsh
-   eval "$(deja init zsh)"
+   if [[ -r "$HOME/.local/share/deja/init.zsh" ]]; then
+     source "$HOME/.local/share/deja/init.zsh"
+   else
+     eval "$(deja init zsh)"
+   fi
    ```
 2. Stop the running daemon:
    ```bash

--- a/README.md
+++ b/README.md
@@ -292,9 +292,19 @@ Deja renders its own ghost text and replaces `zsh-autosuggestions` — don't run
 
 **The daemon seems stuck.**
 ```bash
+deja daemon --restart
+```
+Or stop it and let a fresh terminal auto-respawn it via the init script:
+```bash
 pkill -f 'deja daemon'
 ```
-A fresh terminal will auto-respawn it via the init script.
+
+**Suggestions still work but feel slow after upgrading deja.**
+Daemons outlive shell sessions, so the one still running is from the previous
+version. New shells detect this and fall back to a slower path that keeps
+working; `deja daemon --restart` replaces it. Upgrading from a version older
+than the one that introduced `--restart` needs a one-time `pkill -f 'deja
+daemon'` instead, since those daemons left no pidfile to find them by.
 
 **Stale socket after a crash.**
 ```bash
@@ -342,15 +352,21 @@ score = 1.0 × fuzzy
 ### Architecture
 
 ```
-┌─────────────────┐     JSON/Unix socket      ┌──────────────────────┐
+┌─────────────────┐        Unix socket        ┌──────────────────────┐
 │   zsh widget    │ ──────────────────────▶   │   deja daemon        │
 │  (per keystroke)│ ◀──────────────────────   │  (single process,    │
-└─────────────────┘    suggestion (<1ms)       │   all terminals)     │
-                                               └──────────┬───────────┘
-                                                          │
-                                                    SQLite (WAL)
-                                               commands · stats · seqs
+└─────────────────┘    suggestion (<1ms)      │   all terminals)     │
+                                              └──────────┬───────────┘
+                                                         │
+                                                   SQLite (WAL)
+                                              commands · stats · seqs
 ```
+
+zsh opens that socket itself, via the standard `zsh/net/socket` module, so a
+keystroke costs a connect and a write rather than a process launch — about
+0.3 ms against 35 ms. Where the module is missing, or where the running daemon
+predates this protocol, the shell falls back to invoking `deja query` as a
+subprocess: same suggestions, just slower.
 
 The daemon loads all state into memory at startup (`map[string]*CommandStat`, top-100 directory affinities, sequence pairs) and uses a `sync.RWMutex` so reads never block each other. Writes (command recording) take microseconds.
 

--- a/cmd/deja/daemon.go
+++ b/cmd/deja/daemon.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
+	"time"
 
 	"github.com/giammarcoferranti/deja/internal/config"
 	"github.com/giammarcoferranti/deja/internal/daemon"
@@ -15,18 +19,23 @@ import (
 
 func runDaemon(args []string) {
 	fs := flag.NewFlagSet("daemon", flag.ContinueOnError)
+	restart := fs.Bool("restart", false, "stop the running daemon first, then start")
 	fs.Usage = func() {
 		w := os.Stdout
 		fs.SetOutput(w)
 		fmt.Fprintln(w, "deja daemon — run the suggestion daemon (Unix socket)")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "Usage:")
-		fmt.Fprintln(w, "  deja daemon")
+		fmt.Fprintln(w, "  deja daemon [--restart]")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "Loads the SQLite database (~/.local/share/deja/deja.db) into memory and")
 		fmt.Fprintln(w, "listens on ~/.local/share/deja/sock for suggest/record/ping requests from")
 		fmt.Fprintln(w, "the zsh integration. Normally auto-spawned by the init script — run")
 		fmt.Fprintln(w, "manually only for debugging. Stop with SIGINT/SIGTERM (Ctrl+C).")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Daemons outlive shell sessions, so after upgrading deja the old one keeps")
+		fmt.Fprintln(w, "serving until it is replaced. --restart stops it and starts a new one; use")
+		fmt.Fprintln(w, "it when a new shell reports that the running daemon is out of date.")
 	}
 	parseFlags(fs, args)
 
@@ -39,6 +48,13 @@ func runDaemon(args []string) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "deja daemon: %v\n", err)
 		os.Exit(1)
+	}
+
+	if *restart {
+		if err := stopRunningDaemon(sock); err != nil {
+			fmt.Fprintf(os.Stderr, "deja daemon: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	db, err := store.InitDB(path)
@@ -74,6 +90,57 @@ func runDaemon(args []string) {
 		fmt.Fprintf(os.Stderr, "deja daemon: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// stopRunningDaemon terminates the daemon currently listening on sock and waits
+// for it to release the socket. It is a no-op when nothing is listening.
+//
+// The pidfile is the only handle we have: the wire protocol has no "quit"
+// message, and adding one would not help against precisely the daemon that
+// needs replacing — an older build that predates it. A daemon started before
+// the pidfile existed therefore cannot be stopped from here, and saying so is
+// better than killing something by matching a process name.
+func stopRunningDaemon(sock string) error {
+	pidPath := daemon.PidPath(sock)
+
+	raw, err := os.ReadFile(pidPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if _, statErr := os.Stat(sock); statErr != nil {
+				return nil // nothing listening, nothing to stop
+			}
+			return fmt.Errorf("a daemon is listening on %s but wrote no pidfile "+
+				"(it predates --restart); stop it yourself, e.g. pkill -f 'deja daemon'", sock)
+		}
+		return fmt.Errorf("read %s: %w", pidPath, err)
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 0 {
+		return fmt.Errorf("pidfile %s does not contain a pid (%q)", pidPath, raw)
+	}
+
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			// Daemon died without cleaning up. Clear the stale files so the
+			// fresh one starts from a known state.
+			os.Remove(pidPath)
+			os.Remove(sock)
+			return nil
+		}
+		return fmt.Errorf("signal pid %d: %w", pid, err)
+	}
+
+	// Serve removes the socket on its way out, so its disappearance is the
+	// signal that the port is free.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sock); os.IsNotExist(err) {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("daemon %d did not release %s within 2s", pid, sock)
 }
 
 func sourceLabel(s config.Source, envName string) string {

--- a/cmd/deja/init.go
+++ b/cmd/deja/init.go
@@ -51,8 +51,17 @@ func runInit(args []string) {
 		os.Exit(1)
 	}
 
+	// Baked into the script so the shell can check daemon liveness with a stat on the
+	// socket instead of launching the binary for `ping` on every shell startup.
+	sock, err := sockPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "deja init: %v\n", err)
+		os.Exit(1)
+	}
+
 	initPath := filepath.Join(dir, "init.zsh")
 	script := strings.ReplaceAll(shell.ZshInit(), "{{DEJA_BIN}}", bin)
+	script = strings.ReplaceAll(script, "{{DEJA_SOCK}}", sock)
 	if err := os.WriteFile(initPath, []byte(script), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "deja init: write %s: %v\n", initPath, err)
 		os.Exit(1)

--- a/cmd/deja/init.go
+++ b/cmd/deja/init.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/giammarcoferranti/deja/internal/shell"
 )
@@ -60,12 +61,68 @@ func runInit(args []string) {
 	}
 
 	initPath := filepath.Join(dir, "init.zsh")
-	script := strings.ReplaceAll(shell.ZshInit(), "{{DEJA_BIN}}", bin)
-	script = strings.ReplaceAll(script, "{{DEJA_SOCK}}", sock)
-	if err := os.WriteFile(initPath, []byte(script), 0o644); err != nil {
-		fmt.Fprintf(os.Stderr, "deja init: write %s: %v\n", initPath, err)
+	if err := writeInitScript(initPath, bin, sock); err != nil {
+		fmt.Fprintf(os.Stderr, "deja init: %v\n", err)
 		os.Exit(1)
 	}
 
 	fmt.Printf("source '%s'\n", initPath)
+}
+
+// binaryStamp identifies a build of the deja binary by its stat metadata, in the
+// same `size-mtime-inode` form the generated script rebuilds with `zstat -H`.
+//
+// A version string cannot do this job: main.version is hardcoded to "dev" and
+// only .goreleaser.yaml stamps a real value at release, so every local build
+// reports the same string. Stat metadata distinguishes them.
+func binaryStamp(bin string) string {
+	fi, err := os.Stat(bin)
+	if err != nil {
+		return ""
+	}
+	var inode uint64
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		inode = uint64(st.Ino)
+	}
+	return fmt.Sprintf("%d-%d-%d", fi.Size(), fi.ModTime().Unix(), inode)
+}
+
+// writeInitScript renders the integration script and installs it atomically.
+//
+// The atomicity is not a nicety. `deja init` runs in the background whenever a
+// shell notices the script is stale, so "one shell rewrites init.zsh while
+// another is sourcing it" is a routine event rather than a race you have to go
+// looking for — and a shell that reads a half-written file gets a broken ZLE.
+// os.WriteFile truncates in place, which is exactly the window to avoid; a
+// rename over the target is atomic within a directory. internal/config's
+// writeKey already does this for the same reason.
+func writeInitScript(initPath, bin, sock string) error {
+	script := strings.ReplaceAll(shell.ZshInit(), "{{DEJA_BIN}}", bin)
+	script = strings.ReplaceAll(script, "{{DEJA_SOCK}}", sock)
+	script = strings.ReplaceAll(script, "{{DEJA_BIN_STAMP}}", binaryStamp(bin))
+
+	dir := filepath.Dir(initPath)
+	tmp, err := os.CreateTemp(dir, "init.zsh.tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.WriteString(script); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", tmpPath, err)
+	}
+	// CreateTemp makes the file 0600; the script is not secret and a shell may
+	// source it as another user's login shell would.
+	if err := os.Chmod(tmpPath, 0o644); err != nil {
+		return fmt.Errorf("chmod %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, initPath); err != nil {
+		return fmt.Errorf("install %s: %w", initPath, err)
+	}
+	return nil
 }

--- a/cmd/deja/init_test.go
+++ b/cmd/deja/init_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestWriteInitScript_AtomicUnderConcurrentReads is the reason writeInitScript
+// renames instead of truncating in place. A shell notices a stale script and
+// regenerates it in the background, so "one shell rewrites init.zsh while
+// another is sourcing it" is routine — and a shell that reads a half-written
+// file gets a broken ZLE, silently.
+//
+// os.WriteFile would fail this: readers would observe truncated content.
+func TestWriteInitScript_AtomicUnderConcurrentReads(t *testing.T) {
+	dir := t.TempDir()
+	initPath := filepath.Join(dir, "init.zsh")
+
+	if err := writeInitScript(initPath, "/usr/bin/true", "/tmp/sock"); err != nil {
+		t.Fatalf("initial write: %v", err)
+	}
+	full, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	wantLen := len(full)
+	if wantLen == 0 {
+		t.Fatal("script is empty")
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Readers: every observation must be a whole script, never a prefix.
+	var bad int
+	var mu sync.Mutex
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				got, err := os.ReadFile(initPath)
+				if err != nil {
+					continue // a rename can briefly race an open on some systems
+				}
+				if len(got) != wantLen || !strings.HasSuffix(string(got), "\n") {
+					mu.Lock()
+					bad++
+					mu.Unlock()
+				}
+			}
+		}()
+	}
+
+	// Writers, hammering the same target.
+	var writers sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			for j := 0; j < 60; j++ {
+				if err := writeInitScript(initPath, "/usr/bin/true", "/tmp/sock"); err != nil {
+					t.Errorf("concurrent write: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	writers.Wait()
+	close(stop)
+	wg.Wait()
+
+	if bad != 0 {
+		t.Errorf("%d reads saw a partially written script", bad)
+	}
+}
+
+// The generated script must carry a stamp the shell can compare against, or the
+// self-heal silently never fires.
+func TestWriteInitScript_BakesBinaryStamp(t *testing.T) {
+	dir := t.TempDir()
+	initPath := filepath.Join(dir, "init.zsh")
+
+	bin := filepath.Join(dir, "deja")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	if err := writeInitScript(initPath, bin, "/tmp/sock"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	stamp := binaryStamp(bin)
+	if stamp == "" {
+		t.Fatal("binaryStamp returned empty for an existing file")
+	}
+	if !strings.Contains(string(got), `_DEJA_BIN_STAMP="`+stamp+`"`) {
+		t.Errorf("script does not carry the stamp %q", stamp)
+	}
+	if strings.Contains(string(got), "{{") {
+		t.Error("script still contains an unsubstituted placeholder")
+	}
+
+	// Mode matters: CreateTemp makes 0600, and a script nobody can read is a
+	// broken shell.
+	fi, err := os.Stat(initPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if fi.Mode().Perm() != 0o644 {
+		t.Errorf("mode = %v, want 0644", fi.Mode().Perm())
+	}
+}

--- a/deja.plugin.zsh
+++ b/deja.plugin.zsh
@@ -3,13 +3,23 @@
 # install it via Homebrew or the curl script: https://github.com/Giammarco-Ferranti/deja
 #
 # Enable by adding `deja` to plugins=(...) in ~/.zshrc. This sources deja's zsh
-# integration (the same script as `eval "$(deja init zsh)"`). The integration is
-# already framework-aware and re-binds its widgets on each precmd, so it coexists
-# with Oh My Zsh's own keybinding setup.
+# integration. The integration is already framework-aware and re-binds its
+# widgets on each precmd, so it coexists with Oh My Zsh's own keybinding setup.
 
 if (( ! $+commands[deja] )); then
   print -ru2 -- "[oh-my-zsh] deja plugin: 'deja' not found on \$PATH. Install it (https://github.com/Giammarco-Ferranti/deja), then restart your shell."
   return
 fi
 
-eval "$(deja init zsh)"
+# `deja init zsh` does not print the integration script — it writes it to
+# ~/.local/share/deja/init.zsh and prints a source line for that file. Sourcing
+# the file directly keeps a full binary launch (~25-36ms) off every shell
+# startup; the eval is only the first-run bootstrap, for before the file exists.
+# deja refreshes the file itself, in the background, when the binary changes.
+_deja_init_file="$HOME/.local/share/deja/init.zsh"
+if [[ -r "$_deja_init_file" ]]; then
+  source "$_deja_init_file"
+else
+  eval "$(deja init zsh)"
+fi
+unset _deja_init_file

--- a/install.sh
+++ b/install.sh
@@ -81,8 +81,11 @@ case "${SHELL:-}" in *zsh) is_zsh=1 ;; esac
 if [ "$is_zsh" -eq 1 ]; then
   ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
   "$INSTALL_DIR/$BINARY" import || printf 'Note: deja import failed; you can rerun it manually.\n'
-  if ! grep -qF 'deja init zsh' "$ZSHRC" 2>/dev/null; then
-    printf '\neval "$(deja init zsh)"\n' >> "$ZSHRC"
+  if ! grep -qF 'deja/init.zsh' "$ZSHRC" 2>/dev/null; then
+    # Source the cached integration rather than `eval "$(deja init zsh)"`: that
+    # eval costs a full binary launch on every shell to regenerate a file that
+    # is almost always identical. The eval is only the first-run bootstrap.
+    printf '\nif [[ -r "$HOME/.local/share/deja/init.zsh" ]]; then\n  source "$HOME/.local/share/deja/init.zsh"\nelse\n  eval "$(deja init zsh)"\nfi\n' >> "$ZSHRC"
     printf 'Added deja init to %s\n' "$ZSHRC"
   else
     printf 'deja init already present in %s\n' "$ZSHRC"
@@ -90,6 +93,10 @@ if [ "$is_zsh" -eq 1 ]; then
   printf 'Done. Restart your shell or run: exec zsh\n'
 else
   printf 'Done. To activate deja in zsh, add this to your ~/.zshrc:\n'
-  printf '  eval "$(deja init zsh)"\n'
+  printf '  if [[ -r "$HOME/.local/share/deja/init.zsh" ]]; then\n'
+  printf '    source "$HOME/.local/share/deja/init.zsh"\n'
+  printf '  else\n'
+  printf '    eval "$(deja init zsh)"\n'
+  printf '  fi\n'
   printf 'Then run: deja import\n'
 fi

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1,13 +1,16 @@
 package daemon
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime/debug"
+	"strconv"
 	"time"
 )
 
@@ -15,6 +18,13 @@ const (
 	connDeadline  = 2 * time.Second
 	probeTimeout  = 50 * time.Millisecond
 )
+
+// PidPath returns the pidfile that accompanies a daemon listening on sockPath.
+// Deriving it from the socket keeps a single source of truth for "where the
+// daemon lives", the same way the socket path already is.
+func PidPath(sockPath string) string {
+	return filepath.Join(filepath.Dir(sockPath), "daemon.pid")
+}
 
 // Serve listens on sockPath and dispatches envelopes to the state handlers.
 // It returns when ctx is cancelled or the listener errors. On return the
@@ -41,6 +51,17 @@ func Serve(ctx context.Context, state *State, sockPath string) error {
 		l.Close()
 		os.Remove(sockPath)
 		return fmt.Errorf("chmod %s: %w", sockPath, err)
+	}
+
+	// Written only once the bind has succeeded, so the pidfile means "this
+	// process owns the socket" and never points at a daemon that failed to
+	// start. A failure to write it is not fatal — the daemon still works; only
+	// `deja daemon --restart` loses the ability to identify the process.
+	pidPath := PidPath(sockPath)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "deja daemon: write %s: %v (--restart will not be able to find this daemon)\n", pidPath, err)
+	} else {
+		defer os.Remove(pidPath)
 	}
 
 	go func() {
@@ -95,7 +116,27 @@ func handle(conn net.Conn, state *State) {
 	defer conn.Close()
 	conn.SetDeadline(time.Now().Add(connDeadline))
 
-	dec := json.NewDecoder(conn)
+	// Two request encodings share this socket. Peek one byte to tell them
+	// apart: `{` is JSON, anything else is the text protocol. See text.go for
+	// why zsh gets its own encoding rather than building JSON by hand.
+	//
+	// Routing on `{` alone rather than also skipping leading whitespace is
+	// deliberate. Every JSON client is `json.Encoder`, which never emits leading
+	// whitespace, whereas a stray newline from a text client is plausible — and
+	// handing a lone "\n" to the JSON decoder would hold the connection open for
+	// the full connDeadline waiting for a value that never comes. The text
+	// handler rejects what it does not understand and closes immediately.
+	br := bufio.NewReader(conn)
+	first, err := br.Peek(1)
+	if err != nil {
+		return
+	}
+	if first[0] != '{' {
+		handleText(br, conn, state)
+		return
+	}
+
+	dec := json.NewDecoder(br)
 	enc := json.NewEncoder(conn)
 
 	var env Envelope

--- a/internal/daemon/text.go
+++ b/internal/daemon/text.go
@@ -1,0 +1,216 @@
+package daemon
+
+// A line-oriented alternative to the JSON envelope, for clients that cannot
+// cheaply build JSON — specifically zsh, which now talks to the daemon directly
+// over `zsh/net/socket` so the keystroke path costs no fork+exec at all. Building
+// JSON in zsh would mean hand-rolling string escaping for a format with far more
+// escaping rules than this one needs.
+//
+// Request: one \n-terminated line, fields separated by US (0x1f):
+//
+//	ping
+//	suggest<US>buffer<US>dir<US>prev
+//	record<US>command<US>dir<US>exit<US>duration_ms<US>session<US>prev
+//
+// The newline terminator is what tells the daemon a request is complete. zsh
+// cannot half-close a socket to signal EOF, so the frame has to be
+// self-delimiting — which in turn means a field may contain neither a raw
+// newline nor a raw US. Three characters are escaped:
+//
+//	\  -> \\
+//	LF -> \n
+//	US -> \s
+//
+// Unescaping is strict: an unknown escape is an error rather than a silent
+// passthrough, so a mismatch between this and the zsh side surfaces in tests
+// instead of quietly corrupting somebody's command history.
+//
+// Responses carry no framing and no escaping: the daemon closes the connection
+// when it is done and the client reads to EOF. That makes the suggest response
+// byte-identical to `deja query --format lines`, which the zsh side already
+// knows how to parse, so this protocol changes only how the request travels.
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// textFieldSep separates fields within a request line. US (unit separator)
+	// is the same delimiter `deja query --format lines` already uses for
+	// candidates, so the shell needs only one special byte in mind.
+	textFieldSep = "\x1f"
+
+	// maxTextRequest caps a single request line. Generous next to any real
+	// command line, and the point is only to stop a confused or hostile peer
+	// from making the daemon buffer without bound.
+	maxTextRequest = 64 << 10
+)
+
+// errTextTooLong is returned when a request line exceeds maxTextRequest.
+var errTextTooLong = errors.New("text request too long")
+
+// escapeTextField renders s safe to place in a US-separated, newline-terminated
+// frame. Backslash must be escaped first, or the escapes introduced for the
+// other two characters would themselves be re-escaped.
+func escapeTextField(s string) string {
+	if !strings.ContainsAny(s, "\\\n"+textFieldSep) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 8)
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\x1f':
+			b.WriteString(`\s`)
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}
+
+// unescapeTextField is the inverse of escapeTextField. Unknown escapes and a
+// trailing lone backslash are errors, not best-effort guesses.
+func unescapeTextField(s string) (string, error) {
+	if !strings.Contains(s, `\`) {
+		return s, nil
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] != '\\' {
+			b.WriteByte(s[i])
+			continue
+		}
+		i++
+		if i >= len(s) {
+			return "", errors.New("trailing backslash in text field")
+		}
+		switch s[i] {
+		case '\\':
+			b.WriteByte('\\')
+		case 'n':
+			b.WriteByte('\n')
+		case 's':
+			b.WriteByte('\x1f')
+		default:
+			return "", fmt.Errorf("unknown escape %q in text field", `\`+string(s[i]))
+		}
+	}
+	return b.String(), nil
+}
+
+// parseTextRequest splits a request line into its verb and unescaped fields.
+func parseTextRequest(line string) (string, []string, error) {
+	parts := strings.Split(line, textFieldSep)
+	verb := parts[0]
+	if verb == "" {
+		return "", nil, errors.New("empty verb")
+	}
+	fields := make([]string, 0, len(parts)-1)
+	for _, p := range parts[1:] {
+		f, err := unescapeTextField(p)
+		if err != nil {
+			return "", nil, err
+		}
+		fields = append(fields, f)
+	}
+	return verb, fields, nil
+}
+
+// readTextLine reads up to and including the next newline, refusing to buffer
+// more than max bytes. The newline is not returned.
+func readTextLine(br *bufio.Reader, max int) (string, error) {
+	var b strings.Builder
+	for {
+		c, err := br.ReadByte()
+		if err != nil {
+			return "", err
+		}
+		if c == '\n' {
+			return b.String(), nil
+		}
+		if b.Len() >= max {
+			return "", errTextTooLong
+		}
+		b.WriteByte(c)
+	}
+}
+
+// formatTextCandidates renders a SuggestResp the way `deja query --format lines`
+// does: the primary suggestion first, then alternatives, US-separated, and
+// nothing at all when there is no suggestion.
+func formatTextCandidates(resp SuggestResp) string {
+	if resp.Suggestion == "" {
+		return ""
+	}
+	cands := make([]string, 0, 1+len(resp.Alternatives))
+	cands = append(cands, resp.Suggestion)
+	cands = append(cands, resp.Alternatives...)
+	return strings.Join(cands, textFieldSep)
+}
+
+// handleText serves one text-protocol request. Like the JSON path it answers a
+// single request per connection and lets the caller close the socket, which is
+// what signals end-of-response to the client.
+//
+// A malformed or unknown request draws no response at all — the same treatment
+// the JSON path gives an unknown envelope type. The client learns "this daemon
+// does not understand me" from the empty read, which is exactly how the zsh side
+// detects a daemon too old to speak this protocol.
+func handleText(br *bufio.Reader, w io.Writer, state *State) {
+	line, err := readTextLine(br, maxTextRequest)
+	if err != nil {
+		return
+	}
+
+	verb, fields, err := parseTextRequest(line)
+	if err != nil {
+		return
+	}
+
+	switch verb {
+	case "ping":
+		io.WriteString(w, "pong")
+
+	case "suggest":
+		if len(fields) != 3 {
+			return
+		}
+		resp := state.Suggest(SuggestReq{Buffer: fields[0], Dir: fields[1], Prev: fields[2]}, time.Now())
+		io.WriteString(w, formatTextCandidates(resp))
+
+	case "record":
+		if len(fields) != 6 {
+			return
+		}
+		// A non-numeric exit code or duration is not worth dropping the whole
+		// record over; the command itself is the valuable part.
+		exit, _ := strconv.Atoi(fields[2])
+		dur, _ := strconv.Atoi(fields[3])
+		req := RecordReq{
+			Command:    fields[0],
+			Dir:        fields[1],
+			ExitCode:   exit,
+			DurationMS: dur,
+			SessionID:  fields[4],
+			Prev:       fields[5],
+		}
+		if err := state.Record(req); err != nil {
+			fmt.Fprintf(os.Stderr, "deja daemon: record: %v\n", err)
+			return
+		}
+		io.WriteString(w, "ok")
+	}
+}

--- a/internal/daemon/text_test.go
+++ b/internal/daemon/text_test.go
@@ -1,0 +1,247 @@
+package daemon
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newBufReader(s string) *bufio.Reader { return bufio.NewReader(strings.NewReader(s)) }
+
+func mustLoad(t *testing.T) *State {
+	t.Helper()
+	state, err := Load(newTestDB(t))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	return state
+}
+
+// sendText writes one text-protocol request and reads the response to EOF —
+// exactly what the zsh side does: connect, print one line, read until the
+// daemon closes.
+func sendText(t *testing.T, dial func(t *testing.T) net.Conn, line string) string {
+	t.Helper()
+	conn := dial(t)
+	defer conn.Close()
+	if _, err := io.WriteString(conn, line+"\n"); err != nil {
+		t.Fatalf("write %q: %v", line, err)
+	}
+	out, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("read after %q: %v", line, err)
+	}
+	return string(out)
+}
+
+func TestEscapeUnescape_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"plain", "git status"},
+		{"backslash", `grep -E '\d+' file`},
+		{"double backslash", `printf 'a\\b'`},
+		{"newline", "git commit -m 'line one\nline two'"},
+		{"unit separator", "weird\x1fcommand"},
+		{"all three", "a\\b\nc\x1fd"},
+		{"trailing backslash", `cd C:\`},
+		{"empty", ""},
+		{"non-ascii", "echo 'héllo → 世界'"},
+		{"looks like an escape", `\n \s \\ \q`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			esc := escapeTextField(tc.in)
+			if strings.ContainsAny(esc, "\n\x1f") {
+				t.Fatalf("escaped form still contains a framing byte: %q", esc)
+			}
+			got, err := unescapeTextField(esc)
+			if err != nil {
+				t.Fatalf("unescape(%q): %v", esc, err)
+			}
+			if got != tc.in {
+				t.Errorf("round trip: got %q, want %q", got, tc.in)
+			}
+		})
+	}
+}
+
+// Unescaping is strict on purpose: a mismatch between the Go and zsh sides must
+// fail loudly here rather than silently corrupt a recorded command.
+func TestUnescapeTextField_RejectsGarbage(t *testing.T) {
+	for _, in := range []string{`\`, `a\`, `\q`, `\x1f`, `ok\zbad`} {
+		if got, err := unescapeTextField(in); err == nil {
+			t.Errorf("unescape(%q) = %q, want an error", in, got)
+		}
+	}
+}
+
+func TestParseTextRequest(t *testing.T) {
+	verb, fields, err := parseTextRequest("suggest\x1fgit st\x1f/tmp\x1fls")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if verb != "suggest" {
+		t.Errorf("verb = %q, want suggest", verb)
+	}
+	want := []string{"git st", "/tmp", "ls"}
+	if len(fields) != len(want) {
+		t.Fatalf("fields = %q, want %q", fields, want)
+	}
+	for i := range want {
+		if fields[i] != want[i] {
+			t.Errorf("field %d = %q, want %q", i, fields[i], want[i])
+		}
+	}
+
+	// A verb with no fields is legal (ping).
+	if verb, fields, err := parseTextRequest("ping"); err != nil || verb != "ping" || len(fields) != 0 {
+		t.Errorf("parse(ping) = %q, %q, %v", verb, fields, err)
+	}
+
+	if _, _, err := parseTextRequest(""); err == nil {
+		t.Error("empty line should not parse")
+	}
+	if _, _, err := parseTextRequest("suggest\x1fbad\\qescape\x1f/tmp\x1fls"); err == nil {
+		t.Error("a bad escape in a field should fail the whole request")
+	}
+}
+
+func TestFormatTextCandidates(t *testing.T) {
+	if got := formatTextCandidates(SuggestResp{}); got != "" {
+		t.Errorf("no suggestion should render as empty, got %q", got)
+	}
+	got := formatTextCandidates(SuggestResp{Suggestion: "git status", Alternatives: []string{"git stash", "git show"}})
+	if want := "git status\x1fgit stash\x1fgit show"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadTextLine_CapsLength(t *testing.T) {
+	// No newline within the cap: must fail rather than buffer without bound.
+	huge := strings.Repeat("x", maxTextRequest+10)
+	if _, err := readTextLine(newBufReader(huge), maxTextRequest); err != errTextTooLong {
+		t.Errorf("got %v, want errTextTooLong", err)
+	}
+	// Exactly at the cap, terminated, is fine.
+	ok := strings.Repeat("x", maxTextRequest-1) + "\n"
+	if got, err := readTextLine(newBufReader(ok), maxTextRequest); err != nil || len(got) != maxTextRequest-1 {
+		t.Errorf("len=%d err=%v", len(got), err)
+	}
+	// Unterminated input is an error (io.EOF), never a silent partial request.
+	if _, err := readTextLine(newBufReader("suggest\x1fa"), maxTextRequest); err != io.EOF {
+		t.Errorf("got %v, want io.EOF", err)
+	}
+}
+
+func TestText_Ping(t *testing.T) {
+	dial := startServer(t, mustLoad(t))
+	if got := sendText(t, dial, "ping"); got != "pong" {
+		t.Errorf("ping = %q, want pong", got)
+	}
+}
+
+func TestText_RecordThenSuggest(t *testing.T) {
+	state := mustLoad(t)
+	dial := startServer(t, state)
+
+	if got := sendText(t, dial, "record\x1fgit rebase -i\x1f/repo\x1f0\x1f12\x1fsess\x1fgit status"); got != "ok" {
+		t.Fatalf("record = %q, want ok", got)
+	}
+
+	got := sendText(t, dial, "suggest\x1fgit reb\x1f/repo\x1fgit status")
+	if !strings.HasPrefix(got, "git rebase -i") {
+		t.Errorf("suggest = %q, want the just-recorded command first", got)
+	}
+}
+
+// A command containing the framing bytes must survive the whole trip: escaped by
+// the client, unescaped into the DB, and returned verbatim in a suggestion.
+func TestText_RecordPreservesFramingBytes(t *testing.T) {
+	state := mustLoad(t)
+	dial := startServer(t, state)
+
+	cmd := "echo 'first\nsecond'"
+	req := "record" + textFieldSep + escapeTextField(cmd) +
+		textFieldSep + "/repo" + textFieldSep + "0" + textFieldSep + "1" +
+		textFieldSep + "sess" + textFieldSep + ""
+	if got := sendText(t, dial, req); got != "ok" {
+		t.Fatalf("record = %q, want ok", got)
+	}
+
+	resp := state.Suggest(SuggestReq{Buffer: "echo", Dir: "/repo"}, time.Now())
+	if resp.Suggestion != cmd {
+		t.Errorf("suggestion = %q, want %q", resp.Suggestion, cmd)
+	}
+}
+
+func TestText_MalformedRequestsKeepServerAlive(t *testing.T) {
+	dial := startServer(t, mustLoad(t))
+
+	for _, bad := range []string{
+		"nosuchverb",
+		"suggest",                     // too few fields
+		"suggest\x1fa\x1fb\x1fc\x1fd", // too many
+		"record\x1fonly-one-field",
+		"suggest\x1fbad\\qescape\x1f/tmp\x1fls",
+		"",
+	} {
+		if got := sendText(t, dial, bad); got != "" {
+			t.Errorf("%q drew a response %q, want silence", bad, got)
+		}
+	}
+
+	// The server is still healthy afterwards, on both encodings.
+	if got := sendText(t, dial, "ping"); got != "pong" {
+		t.Errorf("text ping after malformed input = %q", got)
+	}
+}
+
+// The two encodings share one socket, so JSON clients must keep working
+// untouched. Routing is on a leading `{`, which is what json.Encoder — the only
+// JSON client deja has — always emits.
+func TestText_JSONClientsStillWork(t *testing.T) {
+	dial := startServer(t, mustLoad(t))
+
+	conn := dial(t)
+	if _, err := io.WriteString(conn, `{"type":"ping"}`+"\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out, _ := io.ReadAll(conn)
+	conn.Close()
+	if !strings.Contains(string(out), `"pong":true`) {
+		t.Errorf("JSON ping returned %q", out)
+	}
+}
+
+// A lone newline must not be handed to the JSON decoder: it would block until
+// connDeadline waiting for a value. The text handler rejects it and closes.
+func TestText_EmptyLineClosesPromptly(t *testing.T) {
+	dial := startServer(t, mustLoad(t))
+
+	start := time.Now()
+	if got := sendText(t, dial, ""); got != "" {
+		t.Errorf("empty line drew %q, want silence", got)
+	}
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Errorf("empty line took %v to close; it is being parsed as JSON", elapsed)
+	}
+}
+
+func TestText_OversizedRequestIsRejected(t *testing.T) {
+	dial := startServer(t, mustLoad(t))
+
+	conn := dial(t)
+	// No newline, more than the cap: the daemon must give up rather than buffer.
+	io.WriteString(conn, "suggest\x1f"+strings.Repeat("x", maxTextRequest+1024))
+	conn.Close()
+
+	if got := sendText(t, dial, "ping"); got != "pong" {
+		t.Errorf("server unhealthy after oversized request: ping = %q", got)
+	}
+}

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -329,3 +329,90 @@ func TestZshInit_IgnoredCommandBreaksSequenceChain(t *testing.T) {
 		t.Errorf("__deja_prev was not cleared: got %s, want prev=[]", got)
 	}
 }
+
+// escapeCases pins the request-field escaping shared by two languages. The zsh
+// half is `_deja_text_request` in zsh.sh; the Go half is escapeTextField /
+// unescapeTextField in internal/daemon/text.go, whose own round-trip test
+// covers the same inputs. If these two drift, a command containing a backslash,
+// a newline, or a US byte gets silently corrupted on its way into the database
+// — so the agreement is pinned here by running the actual shell code.
+var escapeCases = []struct {
+	name string
+	in   string
+	want string
+}{
+	{"plain", "git status", "git status"},
+	{"backslash", `grep -E '\d+' f`, `grep -E '\\d+' f`},
+	{"double backslash", `printf 'a\\b'`, `printf 'a\\\\b'`},
+	{"newline", "one\ntwo", `one\ntwo`},
+	{"unit separator", "a\x1fb", `a\sb`},
+	{"all three", "a\\b\nc\x1fd", `a\\b\nc\sd`},
+	{"trailing backslash", `cd C:\`, `cd C:\\`},
+	{"empty", "", ""},
+	{"non-ascii", "echo 'héllo → 世界'", "echo 'héllo → 世界'"},
+	{"already looks escaped", `\n \s`, `\\n \\s`},
+}
+
+// TestZshInit_TextRequestEscaping runs _deja_text_request in a real zsh and
+// compares the bytes it produces against what the daemon's parser expects.
+func TestZshInit_TextRequestEscaping(t *testing.T) {
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh not installed; skipping escaping check")
+	}
+
+	script := strings.ReplaceAll(ZshInit(), "{{DEJA_BIN}}", "/nonexistent/deja")
+	script = strings.ReplaceAll(script, "{{DEJA_SOCK}}", "/nonexistent/sock")
+	path := filepath.Join(t.TempDir(), "init.zsh")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	for _, tc := range escapeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Sourcing the script also runs its startup tail; DEJA_BIN points at
+			// nothing, so widget binding and daemon spawn are both no-ops.
+			prog := "source " + path + " >/dev/null 2>&1\n" +
+				"_deja_text_request suggest \"$1\"\n" +
+				"print -rn -- \"$REPLY\"\n"
+			out, err := exec.Command(zsh, "-f", "-c", prog, "zsh", tc.in).Output()
+			if err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			want := "suggest\x1f" + tc.want
+			if string(out) != want {
+				t.Errorf("_deja_text_request(%q)\n got %q\nwant %q", tc.in, out, want)
+			}
+		})
+	}
+}
+
+// TestZshInit_SubprocessFallbackSurvives guards the property that makes the
+// socket transport safe to ship: every path that talks to the daemon must still
+// have a working subprocess route for shells where zsh/net/socket is missing, or
+// where the running daemon is too old to answer.
+func TestZshInit_SubprocessFallbackSurvives(t *testing.T) {
+	script := ZshInit()
+
+	// The capability probe must be a probe, not an assumption.
+	if !strings.Contains(script, "$+builtins[zsocket]") {
+		t.Error("zsocket is used without probing for the builtin; shells without zsh/net/socket would break")
+	}
+
+	// Each hot path keeps its `deja <subcommand>` invocation as a fallback.
+	for _, want := range []string{
+		`"$DEJA_BIN" query --buffer "$buffer"`, // _deja_fetch_suggestion
+		`"$DEJA_BIN" query --buffer "$1"`,      // _deja_async_request
+		`"$DEJA_BIN" record \`,                 // _deja_precmd
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("subprocess fallback %q is gone; a shell without zsocket would lose this path", want)
+		}
+	}
+
+	// An old daemon accepts the connection but never answers, so the probe must
+	// disarm the socket transport rather than leaving the shell mute.
+	if !strings.Contains(script, "_DEJA_ZSOCKET=0") {
+		t.Error("_deja_ensure_daemon never stands down to the subprocess path; a pre-text-protocol daemon would leave the shell with no suggestions")
+	}
+}

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -416,3 +416,133 @@ func TestZshInit_SubprocessFallbackSurvives(t *testing.T) {
 		t.Error("_deja_ensure_daemon never stands down to the subprocess path; a pre-text-protocol daemon would leave the shell with no suggestions")
 	}
 }
+
+// scriptForZsh writes the init script with its placeholders substituted, the
+// way cmd/deja/init.go does, and returns the path.
+func scriptForZsh(t *testing.T) string {
+	t.Helper()
+	script := strings.ReplaceAll(ZshInit(), "{{DEJA_BIN}}", "/nonexistent/deja")
+	script = strings.ReplaceAll(script, "{{DEJA_SOCK}}", "/nonexistent/sock")
+	path := filepath.Join(t.TempDir(), "init.zsh")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	return path
+}
+
+// TestZshInit_SessionIDForksNothing guards a startup cost that is easy to
+// reintroduce. Generating the id by piping /dev/urandom through head/xxd/tr
+// cost 6-13ms of every shell's startup for entropy a session id does not need.
+func TestZshInit_SessionIDForksNothing(t *testing.T) {
+	script := ZshInit()
+
+	start := strings.Index(script, "typeset -g DEJA_SESSION_ID")
+	if start < 0 {
+		t.Fatal("DEJA_SESSION_ID assignment not found")
+	}
+	block := script[start:]
+	if end := strings.Index(block, "\ntypeset -g __deja_prev"); end > 0 {
+		block = block[:end]
+	}
+
+	for _, forked := range []string{"head ", "xxd", "tr ", "$(", "`"} {
+		if strings.Contains(block, forked) {
+			t.Errorf("session id generation runs %q; it must use only shell builtins", forked)
+		}
+	}
+}
+
+// TestZshInit_SessionIDIsUnique checks the replacement actually distinguishes
+// shells, including two started back to back within the same shell's lifetime.
+func TestZshInit_SessionIDIsUnique(t *testing.T) {
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh not installed")
+	}
+	path := scriptForZsh(t)
+
+	seen := map[string]bool{}
+	for i := 0; i < 12; i++ {
+		out, err := exec.Command(zsh, "-f", "-c",
+			"source "+path+" >/dev/null 2>&1; print -rn -- $DEJA_SESSION_ID").Output()
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		id := string(out)
+		if id == "" {
+			t.Fatal("session id is empty")
+		}
+		if seen[id] {
+			t.Errorf("duplicate session id %q across shells", id)
+		}
+		seen[id] = true
+	}
+}
+
+// TestZshInit_RebindGuard pins both halves of the precmd early-out: it must skip
+// the ~5.4ms re-bind when nothing changed, and must NOT skip it when a plugin
+// has replaced a widget deja had wrapped. Getting the second half wrong is the
+// dangerous one — deja's widgets would silently stop being reachable.
+//
+// It also pins that the count settles after startup. The redraw hook and
+// zle-line-init install widgets of their own *after* binding, so a count
+// recorded inside _deja_bind_widgets never matches what the next prompt sees
+// and every prompt re-binds — which is the bug this guard exists to avoid.
+func TestZshInit_RebindGuard(t *testing.T) {
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh not installed")
+	}
+
+	// DEJA_BIN must be executable or the script's startup tail skips binding
+	// entirely; /bin/true is a harmless stand-in that spawns no daemon.
+	script := strings.ReplaceAll(ZshInit(), "{{DEJA_BIN}}", "/usr/bin/true")
+	script = strings.ReplaceAll(script, "{{DEJA_SOCK}}", "/nonexistent/sock")
+	path := filepath.Join(t.TempDir(), "init.zsh")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	// precmd's rebind block, verbatim in shape.
+	precmd := `
+		_deja_widgets_unchanged || _deja_bind_widgets
+		_deja_apply_keybindings
+		_deja_install_redraw_hook
+		_DEJA_BOUND_WIDGET_COUNT=${#widgets}
+	`
+
+	prog := `
+		source ` + path + ` >/dev/null 2>&1
+
+		# Startup has bound and recorded. The very next prompt must skip.
+		_deja_widgets_unchanged && print -r -- "afterstartup:skip" || print -r -- "afterstartup:rebind"
+
+		# A framework adding a widget changes the count.
+		zle -N some-new-plugin-widget _deja_noop 2>/dev/null
+		_deja_widgets_unchanged && print -r -- "added:skip" || print -r -- "added:rebind"
+` + precmd + `
+		# ...and the prompt after that settles again.
+		_deja_widgets_unchanged && print -r -- "settled:skip" || print -r -- "settled:rebind"
+
+		# A framework *replacing* a widget deja wrapped leaves the count alone.
+		zle -N self-insert 2>/dev/null
+		_deja_widgets_unchanged && print -r -- "stolen:skip" || print -r -- "stolen:rebind"
+` + precmd + `
+		[[ ${widgets[self-insert]} == user:_deja_bound_* ]] && print -r -- "repaired:yes" || print -r -- "repaired:no"
+	`
+	out, err := exec.Command(zsh, "-f", "-c", prog).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run: %v\n%s", err, out)
+	}
+
+	got := strings.Fields(string(out))
+	want := []string{"afterstartup:skip", "added:rebind", "settled:skip", "stolen:rebind", "repaired:yes"}
+	if len(got) != len(want) {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("step %d: got %q, want %q (full: %q)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -3,13 +3,15 @@
 # wrapped (not replaced), suggestions render via POSTDISPLAY + region_highlight,
 # and fetches run asynchronously via `zle -F` so the keystroke path never blocks.
 #
-# The DEJA_BIN value below is substituted to an absolute path by `deja init`.
+# The DEJA_BIN and DEJA_SOCK values below are substituted to absolute paths by
+# `deja init`.
 
 #--------------------------------------------------------------------#
 # 1. Globals & config                                                #
 #--------------------------------------------------------------------#
 
 typeset -g DEJA_BIN="{{DEJA_BIN}}"
+typeset -g DEJA_SOCK="{{DEJA_SOCK}}"
 
 : ${DEJA_HIGHLIGHT_STYLE:=fg=8}
 : ${DEJA_USE_ASYNC:=1}
@@ -149,7 +151,19 @@ _deja_warn_conflict() {
 _deja_ensure_daemon() {
 	[[ -x "$DEJA_BIN" ]] || return 1
 
-	# Fast path: ping succeeds, daemon is up.
+	# A socket file means a daemon is almost certainly up, so confirm it in the
+	# background rather than blocking the shell on a ~25ms process launch. `-S`
+	# also passes for a socket a crashed daemon left behind, which is what the
+	# backgrounded ping catches — until it respawns, `query` falls back to
+	# reading SQLite, so a wrong guess costs latency, never suggestions.
+	if [[ -S "$DEJA_SOCK" ]]; then
+		{ ( "$DEJA_BIN" ping >/dev/null 2>&1 || "$DEJA_BIN" daemon >/dev/null 2>&1 ) &! } 2>/dev/null
+		return 0
+	fi
+
+	# No socket: a cold start, worth blocking for so the first keystroke does not
+	# race the daemon. Ping first anyway, in case DEJA_SOCK is stale or the
+	# daemon is listening somewhere this script does not know about.
 	"$DEJA_BIN" ping >/dev/null 2>&1 && return 0
 
 	# Spawn detached. `&!` disowns immediately so the daemon outlives this shell.

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -13,6 +13,17 @@
 typeset -g DEJA_BIN="{{DEJA_BIN}}"
 typeset -g DEJA_SOCK="{{DEJA_SOCK}}"
 
+# Every request to the daemon can travel one of two ways. When zsh can open the
+# socket itself — zsh/net/socket is a standard module, present in stock zsh 5.9
+# — a request costs a connect and a write. When it cannot, each request costs a
+# fork+exec of the deja binary instead: ~30ms against ~0.3ms, on a path that runs
+# on every keystroke. The subprocess path stays as a complete fallback, never as
+# the default. See internal/daemon/text.go for the wire format.
+typeset -gi _DEJA_ZSOCKET=0
+if zmodload zsh/net/socket 2>/dev/null && (( $+builtins[zsocket] )); then
+	_DEJA_ZSOCKET=1
+fi
+
 : ${DEJA_HIGHLIGHT_STYLE:=fg=8}
 : ${DEJA_USE_ASYNC:=1}
 : ${DEJA_MANUAL_REBIND:=}
@@ -145,17 +156,72 @@ _deja_warn_conflict() {
 }
 
 #--------------------------------------------------------------------#
-# 2. Daemon auto-spawn                                               #
+# 2. Daemon transport & auto-spawn                                   #
 #--------------------------------------------------------------------#
+
+# Opens a connection to the daemon, leaving the file descriptor in REPLY.
+# Returns non-zero when zsh cannot open sockets or nothing is listening — both
+# mean "use the subprocess path".
+_deja_connect() {
+	(( _DEJA_ZSOCKET )) || return 1
+	[[ -n "$DEJA_SOCK" ]] || return 1
+	zsocket "$DEJA_SOCK" 2>/dev/null
+}
+
+# Builds a request line in REPLY: the verb, then each field escaped and
+# US-separated. The daemon frames requests by newline (zsh cannot half-close a
+# socket to signal EOF), so a field may contain neither a raw newline nor a raw
+# US. These three substitutions are the exact inverse of unescapeTextField in
+# internal/daemon/text.go and must stay in lockstep with it — backslash first,
+# or the escapes introduced below would themselves be re-escaped.
+_deja_text_request() {
+	local f out=$1
+	shift
+	for f in "$@"; do
+		f=${f//\\/\\\\}
+		f=${f//$'\n'/\\n}
+		f=${f//$'\x1f'/\\s}
+		out+=$'\x1f'$f
+	done
+	REPLY=$out
+}
 
 _deja_ensure_daemon() {
 	[[ -x "$DEJA_BIN" ]] || return 1
 
-	# A socket file means a daemon is almost certainly up, so confirm it in the
-	# background rather than blocking the shell on a ~25ms process launch. `-S`
-	# also passes for a socket a crashed daemon left behind, which is what the
-	# backgrounded ping catches — until it respawns, `query` falls back to
-	# reading SQLite, so a wrong guess costs latency, never suggestions.
+	if (( _DEJA_ZSOCKET )); then
+		local -i fd
+		if _deja_connect; then
+			fd=$REPLY
+
+			# A daemon predating the text protocol accepts the connection and then
+			# closes without answering. It cannot be upgraded in place: the wire
+			# protocol has no "quit", and adding one would not reach precisely the
+			# builds that need replacing. So this shell stands down to the
+			# subprocess path — correct, merely slower — until the daemon is
+			# replaced by a reboot or `deja daemon --restart`.
+			local pong
+			if print -u $fd -r -- ping 2>/dev/null; then
+				IFS= read -rd '' -t 0.5 -u $fd pong 2>/dev/null
+			fi
+			exec {fd}<&-
+
+			[[ "$pong" == pong ]] && return 0
+			_DEJA_ZSOCKET=0
+			return 0
+		fi
+
+		# Nothing listening. Spawn detached and return without waiting: a retry
+		# loop here would be startup latency spent for nothing, since until the
+		# daemon is up `query` falls back to reading SQLite directly.
+		{ "$DEJA_BIN" daemon >/dev/null 2>&1 &! } 2>/dev/null
+		return 0
+	fi
+
+	# No zsocket: fall back to a stat. A socket file means a daemon is almost
+	# certainly up, so confirm it in the background rather than blocking the
+	# shell on a ~25ms process launch. `-S` also passes for a socket a crashed
+	# daemon left behind, which is what the backgrounded ping catches.
 	if [[ -S "$DEJA_SOCK" ]]; then
 		{ ( "$DEJA_BIN" ping >/dev/null 2>&1 || "$DEJA_BIN" daemon >/dev/null 2>&1 ) &! } 2>/dev/null
 		return 0
@@ -247,20 +313,39 @@ _deja_highlight_apply() {
 # suggestion" and leaves POSTDISPLAY untouched upstream.
 _deja_fetch_suggestion() {
 	local buffer="$1"
+
+	local -i fd
+	if _deja_connect; then
+		fd=$REPLY
+		_deja_text_request suggest "$buffer" "$PWD" "$__deja_prev"
+		if print -u $fd -r -- "$REPLY" 2>/dev/null; then
+			# Bounded, because this is the synchronous path and a wedged daemon
+			# must not freeze the line editor. The subprocess path applies the
+			# same kind of ceiling internally (readTimeout in cmd/deja/query.go).
+			# A timeout leaves `suggestion` empty, which reads as "no suggestion".
+			IFS= read -rd '' -t 0.5 -u $fd suggestion 2>/dev/null
+			exec {fd}<&-
+			return 0
+		fi
+		exec {fd}<&-
+	fi
+
 	[[ -x "$DEJA_BIN" ]] || return 0
 	suggestion="$("$DEJA_BIN" query --buffer "$buffer" --dir "$PWD" --prev "$__deja_prev" --format lines 2>/dev/null)"
 }
 
-_deja_async_request() {
-	zmodload zsh/system 2>/dev/null
+# Drops any in-flight request so a stale response can't paint over the buffer.
+_deja_async_cancel() {
+	[[ -n "$_DEJA_ASYNC_FD" ]] || return 0
 
-	typeset -g _DEJA_ASYNC_FD _DEJA_CHILD_PID
-
-	# Cancel any pending request so stale responses can't paint over the buffer.
-	if [[ -n "$_DEJA_ASYNC_FD" ]] && { true <&$_DEJA_ASYNC_FD } 2>/dev/null; then
-		builtin exec {_DEJA_ASYNC_FD}<&-
+	if { true <&$_DEJA_ASYNC_FD } 2>/dev/null; then
+		# Unregister before closing: a handler left armed on a closed descriptor
+		# would read from whatever recycled the number.
 		zle -F $_DEJA_ASYNC_FD 2>/dev/null
+		builtin exec {_DEJA_ASYNC_FD}<&-
 
+		# Only the subprocess path has a child to stop; over a socket, closing the
+		# descriptor is the whole of cancellation.
 		if [[ -n "$_DEJA_CHILD_PID" ]]; then
 			if [[ -o MONITOR ]]; then
 				kill -TERM -$_DEJA_CHILD_PID 2>/dev/null
@@ -268,6 +353,32 @@ _deja_async_request() {
 				kill -TERM $_DEJA_CHILD_PID 2>/dev/null
 			fi
 		fi
+	fi
+
+	_DEJA_ASYNC_FD=
+	_DEJA_CHILD_PID=
+}
+
+_deja_async_request() {
+	zmodload zsh/system 2>/dev/null
+
+	typeset -g _DEJA_ASYNC_FD _DEJA_CHILD_PID
+
+	_deja_async_cancel
+
+	local -i fd
+	if _deja_connect; then
+		fd=$REPLY
+		_deja_text_request suggest "$1" "$PWD" "$__deja_prev"
+		if print -u $fd -r -- "$REPLY" 2>/dev/null; then
+			_DEJA_ASYNC_FD=$fd
+			_DEJA_CHILD_PID=
+			# The daemon closes once it has written, so the same handler that
+			# drains a process substitution drains this: read to EOF, paint.
+			zle -F "$fd" _deja_async_response
+			return
+		fi
+		exec {fd}<&-
 	fi
 
 	builtin exec {_DEJA_ASYNC_FD}< <(
@@ -290,7 +401,11 @@ _deja_async_response() {
 	local suggestion
 
 	if [[ -z "$2" || "$2" == "hup" ]]; then
-		IFS='' read -rd '' -u $1 suggestion 2>/dev/null
+		# Bounded read. Over a process substitution EOF always arrives, because
+		# the child exits; over a socket it arrives only if the daemon closes, so
+		# an unbounded read here would let a wedged daemon freeze the line editor.
+		# A timeout just leaves the ghost unpainted until the next keystroke.
+		IFS='' read -rd '' -t 0.5 -u $1 suggestion 2>/dev/null
 		zle deja-suggest -- "$suggestion"
 		# Close only if the fd is still ours — another zle -F user may have
 		# recycled the number. (Never `2>/dev/null` a bare exec: that makes
@@ -835,7 +950,21 @@ _deja_precmd() {
 			(( duration_ms < 0 )) && duration_ms=0
 		fi
 
-		if [[ -x "$DEJA_BIN" ]]; then
+		local -i recorded=0 fd
+		if _deja_connect; then
+			fd=$REPLY
+			_deja_text_request record "$__deja_last_cmd" "$PWD" "$exit_code" \
+				"$duration_ms" "$DEJA_SESSION_ID" "$__deja_prev"
+			# Fire and forget. Reading the ack would mean waiting on the daemon's
+			# SQLite write, and a busy database must never stall the prompt — while
+			# the only failure the ack could report (a write error) would hit the
+			# subprocess fallback just as hard, since it writes to the same file.
+			# A dead daemon is caught earlier, by the connect.
+			print -u $fd -r -- "$REPLY" 2>/dev/null && recorded=1
+			exec {fd}<&-
+		fi
+
+		if (( ! recorded )) && [[ -x "$DEJA_BIN" ]]; then
 			{ "$DEJA_BIN" record \
 				--command "$__deja_last_cmd" \
 				--dir "$PWD" \

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -115,13 +115,26 @@ DEJA_IGNORE_WIDGETS=(
 typeset -ga _DEJA_BUILTIN_ACTIONS
 _DEJA_BUILTIN_ACTIONS=(clear fetch suggest accept partial_accept execute enable disable toggle cycle cycle_fuzzy cycle_fuzzy_back toggle_empty)
 
+zmodload zsh/datetime 2>/dev/null  # $EPOCHREALTIME, for session ids and timings
+
+# A session id groups commands so consecutive pairs can be learned. It is not a
+# secret and not a token: the only cost of a collision is two shells' sequence
+# data being merged. It was drawing 128 bits from /dev/urandom through
+# `head | xxd | tr` — three forked processes, measured at 6-13ms of every
+# shell's startup, for entropy nothing here needs.
+#
+# pid plus microsecond timestamp is already unique in practice: two live shells
+# cannot share a pid, and $RANDOM separates the case where a pid is recycled
+# within the same microsecond. All three are shell builtins, so this forks
+# nothing.
+#
+# Reading /dev/urandom with zsh/system's sysread avoids the forks too, and was
+# tried first — but random bytes are not a valid character string. Across 300
+# reads only 181 kept all 16 bytes; the rest silently lost one to three to NUL
+# and multibyte handling, making the id's length depend on the locale.
 typeset -g DEJA_SESSION_ID
 if [[ -z "$DEJA_SESSION_ID" ]]; then
-	if [[ -r /dev/urandom ]] && (( $+commands[xxd] )); then
-		DEJA_SESSION_ID="$(head -c 16 /dev/urandom | xxd -p 2>/dev/null | tr -d '\n')"
-	else
-		DEJA_SESSION_ID="$$-$RANDOM-$EPOCHSECONDS"
-	fi
+	DEJA_SESSION_ID="$$-${EPOCHREALTIME:-$SECONDS}-$RANDOM"
 fi
 
 typeset -g __deja_prev=""
@@ -847,6 +860,28 @@ _deja_bind_widget() {
 	zle -N -- $widget _deja_bound_${bind_count}_$widget
 }
 
+# Set by _deja_bind_widgets to the widget count it last left behind, so the
+# precmd re-bind can tell "nothing has changed" from "a plugin moved something".
+typeset -gi _DEJA_BOUND_WIDGET_COUNT=-1
+
+# True when the widget table still looks exactly as _deja_bind_widgets left it.
+#
+# _deja_bind_widgets runs on every precmd, not just at startup, because plugins
+# and frameworks add and replace widgets after deja loads. It costs ~5.4ms —
+# iterating ~600 widgets and pattern-matching each against the ignore list —
+# which was the largest remaining per-prompt cost, paid before every prompt for
+# a table that almost never changes.
+#
+# The count alone is too weak a test: the failure this re-binding exists for is
+# a framework *replacing* a widget, which leaves the count identical. So also
+# spot-check that our wrapper is still installed on self-insert, the widget
+# every keystroke goes through and the one whose loss would be most visible.
+_deja_widgets_unchanged() {
+	(( _DEJA_BOUND_WIDGET_COUNT >= 0 )) || return 1
+	(( ${#widgets} == _DEJA_BOUND_WIDGET_COUNT )) || return 1
+	[[ ${widgets[self-insert]} == user:_deja_bound_* ]]
+}
+
 _deja_bind_widgets() {
 	emulate -L zsh
 
@@ -985,15 +1020,26 @@ _deja_precmd() {
 	# frequently rebind Tab during their own precmd, and deja's widgets
 	# become unreachable without this.
 	if [[ -z "$DEJA_MANUAL_REBIND" ]] && ! _deja_conflicting_plugin && [[ -x "$DEJA_BIN" ]]; then
-		_deja_bind_widgets
+		# Skipped when the widget table is untouched since the last bind, which is
+		# the overwhelmingly common case; see _deja_widgets_unchanged.
+		_deja_widgets_unchanged || _deja_bind_widgets
+
+		# Keybindings are re-asserted unconditionally: eight bindkey calls, too
+		# cheap to be worth guarding, and frameworks rebind Tab during their own
+		# precmd — which leaves the widget table identical while making deja's
+		# widgets unreachable, so the check above would not catch it.
 		_deja_apply_keybindings
+
 		# Same reasoning for the redraw hook: a plugin that takes over
 		# zle-line-pre-redraw with a bare `zle -N` drops us off the chain.
 		_deja_install_redraw_hook
+
+		# Recorded after the whole sequence, not inside _deja_bind_widgets: the
+		# redraw hook installs widgets of its own, so a count taken mid-sequence
+		# never matches what the next prompt sees, and every prompt would re-bind.
+		_DEJA_BOUND_WIDGET_COUNT=${#widgets}
 	fi
 }
-
-zmodload zsh/datetime 2>/dev/null  # For $EPOCHREALTIME
 
 add-zsh-hook preexec _deja_preexec
 add-zsh-hook precmd _deja_precmd
@@ -1154,4 +1200,5 @@ elif [[ -x "$DEJA_BIN" ]]; then
 	_deja_bind_widgets
 	_deja_apply_keybindings
 	_deja_install_redraw_hook
+	_DEJA_BOUND_WIDGET_COUNT=${#widgets}
 fi

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -3,8 +3,8 @@
 # wrapped (not replaced), suggestions render via POSTDISPLAY + region_highlight,
 # and fetches run asynchronously via `zle -F` so the keystroke path never blocks.
 #
-# The DEJA_BIN and DEJA_SOCK values below are substituted to absolute paths by
-# `deja init`.
+# The DEJA_BIN, DEJA_SOCK and DEJA_BIN_STAMP values below are substituted by
+# `deja init`, which writes this file to ~/.local/share/deja/init.zsh.
 
 #--------------------------------------------------------------------#
 # 1. Globals & config                                                #
@@ -12,6 +12,10 @@
 
 typeset -g DEJA_BIN="{{DEJA_BIN}}"
 typeset -g DEJA_SOCK="{{DEJA_SOCK}}"
+
+# Stat identity (size-mtime-inode) of the binary that generated this file, so a
+# shell can tell whether the cached script still matches the installed deja.
+typeset -g _DEJA_BIN_STAMP="{{DEJA_BIN_STAMP}}"
 
 # Every request to the daemon can travel one of two ways. When zsh can open the
 # socket itself — zsh/net/socket is a standard module, present in stock zsh 5.9
@@ -1190,6 +1194,35 @@ _deja_apply_keybindings() {
 	[[ -n "$DEJA_TOGGLE_EMPTY_KEY" ]]     && bindkey "$DEJA_TOGGLE_EMPTY_KEY"     deja-toggle_empty
 }
 
+# Regenerate this file when the installed binary is no longer the one that
+# produced it — after a `brew upgrade`, say, which would otherwise leave every
+# shell sourcing the previous release's integration indefinitely.
+#
+# This is why deja can document `source ~/.local/share/deja/init.zsh` as the
+# supported fast path instead of `eval "$(deja init zsh)"`. That eval spends a
+# full binary launch, ~25-36ms on every shell, regenerating a file that is
+# almost always byte-identical. Here the check is a stat and a string compare:
+# 0.083ms, no fork.
+#
+# The regeneration itself is disowned and its result is deliberately not used by
+# this shell — that would put the launch back on the startup path, which is the
+# whole thing being avoided. The next shell picks it up. `deja init` installs the
+# file with a rename, so a shell sourcing it concurrently never sees a partial
+# write.
+_deja_refresh_init_script() {
+	[[ -n "$_DEJA_BIN_STAMP" ]] || return 0
+	[[ -x "$DEJA_BIN" ]] || return 0
+	zmodload zsh/stat 2>/dev/null || return 0
+	(( $+builtins[zstat] )) || return 0
+
+	local -A st
+	zstat -H st "$DEJA_BIN" 2>/dev/null || return 0
+	[[ "${st[size]}-${st[mtime]}-${st[inode]}" == "$_DEJA_BIN_STAMP" ]] && return 0
+
+	{ "$DEJA_BIN" init zsh >/dev/null 2>&1 &! } 2>/dev/null
+}
+
+_deja_refresh_init_script
 _deja_ensure_daemon
 
 # Don't wrap widgets or grab keybindings when another suggestion engine owns


### PR DESCRIPTION
> **Stack** — merge bottom-up:
>
> - **#88** ⬅
> - #87
> - #84
> - #81
>
> Targets `main` because the parent branch lives on my fork and GitHub needs the
> base branch to exist in this repo, so *Files changed* also contains the commits
> below this one. The **Commits** tab separates them.

## Why

`deja init zsh` **does not print the integration script.** It writes it to
`~/.local/share/deja/init.zsh` and prints a `source` line for that file. So the documented
`eval "$(deja init zsh)"` spends a full binary launch — **~25–36 ms on every shell you open** —
regenerating a file that is almost always byte-identical.

Sourcing the file directly is the obvious fix, and the only reason not to document it was that
nothing kept it current: after a `brew upgrade`, every shell would go on sourcing the previous
release's integration indefinitely.

## What

**Each shell checks whether the cache still matches the binary.** The generated script carries
the stat identity (`size-mtime-inode`) of the binary that produced it; the shell rebuilds that
with `zstat -H` and compares — **0.083 ms, no fork**. On a mismatch it regenerates in the
background and carries on with the script it already has. The *next* shell picks up the new
one, so regeneration never lands on the startup path, which is the whole point.

A version string cannot do this job: `main.version` is hardcoded to `"dev"` and only
`.goreleaser.yaml` stamps a real value at release, so every local build reports the same
string. Stat metadata distinguishes them — and a real upgrade changes the inode even when it
lands in the same second as the mtime it replaces.

**Writing the script is now atomic.** `os.WriteFile` truncates in place. With regeneration
happening in the background, "one shell rewrites `init.zsh` while another is sourcing it" stops
being a race you have to go looking for, and a shell that reads a half-written file gets a
broken ZLE, silently. `writeInitScript` renames a temp file over the target, the way
`internal/config`'s `writeKey` already does.

**Docs.** `README.md`, `install.sh`, `deja.plugin.zsh` and the brew caveats now all recommend:

```zsh
if [[ -r "$HOME/.local/share/deja/init.zsh" ]]; then
  source "$HOME/.local/share/deja/init.zsh"
else
  eval "$(deja init zsh)"
fi
```

`if`/`fi` rather than `&&`/`||` on purpose — with `&&`/`||`, a `source` whose last command
returns non-zero would also run the `eval` and double-initialise.

## A plan correction

The handoff proposed hanging this check off `deja record`, which runs after every command and
is already off the latency path. **That no longer holds.** Since #84, the shell talks to the
daemon over its socket, so `record` rarely spawns a process at all — the self-heal would almost
never have run. Hence the check moving into the shell, where it costs a `zstat`.

## Verification

`go test -race ./...` and `go vet ./...` clean.

`TestWriteInitScript_AtomicUnderConcurrentReads` runs 3 writers against 4 readers and asserts
every read observes a whole script. **Negative control:** reverting to `os.WriteFile` makes it
fail with `127 reads saw a partially written script`.

`TestWriteInitScript_BakesBinaryStamp` checks the stamp is present, no `{{placeholder}}`
survives, and the mode is 0644 (`CreateTemp` makes 0600, and a script nobody can read is a
broken shell).

End to end against a live daemon, through the real generated script:

| case | result |
|---|---|
| fresh binary | no regeneration |
| binary replaced (new inode, as `brew upgrade` does) | regenerates in background |
| after regeneration | stable, no repeat |
| post-upgrade shell | `zsocket=1`, suggestions correct |


