### PR TITLE
fix: load only zstat from zsh/stat so /usr/bin/stat is not shadowed

### DIFF
--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -546,3 +546,55 @@ func TestZshInit_RebindGuard(t *testing.T) {
 		}
 	}
 }
+
+// TestZshInit_DoesNotShadowStat is the regression test for #100.
+//
+// _deja_refresh_init_script needs zstat, which lives in zsh/stat. Loading that
+// module unrestricted also defines a `stat` builtin, and a builtin wins over
+// $PATH for the rest of the shell's life. Since deja is sourced from .zshrc,
+// every subsequent `stat -c %s file` in that shell — in the user's own
+// functions, scripts and prompt — stops reaching /usr/bin/stat and fails with
+// "bad option: -c".
+//
+// The check runs the real script under a real zsh rather than grepping for the
+// flags, because the thing that matters is which `stat` the shell resolves
+// afterwards, not how the module was spelled.
+func TestZshInit_DoesNotShadowStat(t *testing.T) {
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh not installed; skipping stat-shadowing check")
+	}
+
+	// DEJA_BIN has to be executable or _deja_refresh_init_script returns before
+	// it ever loads the module, and the test would pass without exercising
+	// anything. /usr/bin/true is a harmless stand-in: the stamp will not match,
+	// so the disowned `true init zsh` it spawns does nothing.
+	script := strings.ReplaceAll(ZshInit(), "{{DEJA_BIN}}", "/usr/bin/true")
+	script = strings.ReplaceAll(script, "{{DEJA_SOCK}}", "/nonexistent/sock")
+	path := filepath.Join(t.TempDir(), "init.zsh")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	prog := "source " + path + " >/dev/null 2>&1\n" +
+		"print -r -- \"stat=[$(whence -w stat)]\"\n" +
+		"print -r -- \"zstat=[$(( $+builtins[zstat] ))]\"\n"
+
+	out, err := exec.Command(zsh, "-f", "-c", prog).Output()
+	if err != nil {
+		t.Fatalf("zsh failed: %v", err)
+	}
+	got := string(out)
+
+	// The whole point: `stat` must not have become a builtin. Asserting on
+	// "not a builtin" rather than on "is a command" keeps the test honest on
+	// an image where coreutils' stat is absent entirely.
+	if strings.Contains(got, "stat: builtin") {
+		t.Errorf("zsh/stat was loaded unrestricted and shadowed /usr/bin/stat:\n%s", got)
+	}
+	// ...and the builtin deja actually wants must still be there, or the
+	// init-script refresh silently stops working.
+	if !strings.Contains(got, "zstat=[1]") {
+		t.Errorf("zstat builtin is missing; _deja_refresh_init_script cannot work:\n%s", got)
+	}
+}

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -1212,7 +1212,13 @@ _deja_apply_keybindings() {
 _deja_refresh_init_script() {
 	[[ -n "$_DEJA_BIN_STAMP" ]] || return 0
 	[[ -x "$DEJA_BIN" ]] || return 0
-	zmodload zsh/stat 2>/dev/null || return 0
+	# -F b:zstat loads *only* the zstat builtin. A bare `zmodload zsh/stat` also
+	# defines a `stat` builtin, and a builtin outranks $PATH for the rest of the
+	# shell's life — so every later `stat -c ...` in that shell reaches zsh's
+	# stat, which has no -c and fails with "bad option: -c". deja is sourced from
+	# .zshrc, so the breakage lands on the user's own scripts and functions, far
+	# from anything that looks like deja's fault.
+	zmodload -F zsh/stat b:zstat 2>/dev/null || return 0
 	(( $+builtins[zstat] )) || return 0
 
 	local -A st


### PR DESCRIPTION
Fixes #100.

## The problem

`_deja_refresh_init_script` needs `zstat`, and loads it with a bare `zmodload zsh/stat`. That module defines **two** builtins: `zstat` and `stat`. A builtin outranks `$PATH` for the rest of the shell's life, so from the moment deja is sourced, every `stat` in that shell reaches zsh's builtin instead of `/usr/bin/stat`:

```
% zsh -fc 'zmodload zsh/stat; whence -w stat; stat -c %s /etc/hostname'
stat: builtin
zsh:stat:1: bad option: -c
```

Because deja is sourced from `.zshrc`, the breakage lands in the user's own functions, scripts and prompt — a long way from anything that looks like deja's doing. It also reaches non-interactive tooling wherever `.zshrc` is on the path.

## The fix

```diff
-	zmodload zsh/stat 2>/dev/null || return 0
+	zmodload -F zsh/stat b:zstat 2>/dev/null || return 0
```

`-F b:zstat` loads only the builtin the function actually uses. `stat` stays the external command, and the existing `(( $+builtins[zstat] ))` guard below still passes:

```
% zsh -fc 'zmodload -F zsh/stat b:zstat; whence -w stat; stat -c %s /etc/hostname'
stat: command
11
```

`zsh/net/socket` is left as-is deliberately — it only defines `zsocket`, which shadows nothing.

## Testing

Added `TestZshInit_DoesNotShadowStat`, which sources the real script under a real zsh and asserts on which `stat` the shell resolves afterwards, rather than grepping for the flags. It fails on `main` and passes with the fix:

```
--- FAIL: TestZshInit_DoesNotShadowStat
    shell_test.go:593: zsh/stat was loaded unrestricted and shadowed /usr/bin/stat:
        stat=[stat: builtin]
```

`go vet ./...` and `go test -race ./...` pass. Verified on zsh 5.9 / Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)