### PR TITLE
fix: release inherited pipes in the daemon so a capturing caller is not held open

### DIFF
--- a/cmd/deja/daemon.go
+++ b/cmd/deja/daemon.go
@@ -86,6 +86,14 @@ func runDaemon(args []string) {
 	defer cancel()
 
 	fmt.Fprintf(os.Stderr, "deja daemon: listening on %s\n", sock)
+
+	// Everything that can fail during startup has now reported, so this is the
+	// point past which the process only blocks. Let go of any inherited pipe
+	// before doing so -- see releasePipedStdio. A bind failure below is the one
+	// message a piped caller loses, and that path exits immediately rather than
+	// blocking, so nothing hangs waiting to read it.
+	releasePipedStdio()
+
 	if err := daemon.Serve(ctx, state, sock); err != nil {
 		fmt.Fprintf(os.Stderr, "deja daemon: %v\n", err)
 		os.Exit(1)

--- a/cmd/deja/stdio.go
+++ b/cmd/deja/stdio.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// releasePipedStdio points any of the daemon's standard descriptors that is an
+// inherited pipe at /dev/null, and reports how many it released.
+//
+// The daemon outlives the shell that spawned it, so every descriptor it keeps,
+// it keeps for hours. When one of them is the write end of a command
+// substitution's pipe, the shell reading that pipe never sees EOF and waits
+// forever: the hang in #101, which presents as a plugin-manager update that
+// never returns while the daemon itself sits there perfectly healthy, and as a
+// reader blocked in anon_pipe_read with no child process left to blame.
+//
+// The init script redirects on every spawn path it owns, but it can only cover
+// the paths it owns. A plugin-manager hook, a CI step, or a hand-written
+// `deja daemon &` hands the daemon whatever the caller happened to have open,
+// and an init.zsh cached from an older release keeps doing whatever it did.
+// Releasing the pipe here covers all of them at once, without depending on
+// every caller getting its redirections right.
+//
+// A terminal is deliberately left alone, so running `deja daemon` by hand stays
+// readable, and so is a regular file, so `deja daemon 2>log` still collects
+// logs. Only a pipe can deadlock a reader, so only a pipe is released.
+func releasePipedStdio() int { return releasePiped(os.Stdin, os.Stdout, os.Stderr) }
+
+func releasePiped(files ...*os.File) int {
+	var piped []*os.File
+	for _, f := range files {
+		if isPipe(f) {
+			piped = append(piped, f)
+		}
+	}
+	if len(piped) == 0 {
+		return 0
+	}
+
+	// Say so before letting go. Someone who piped the daemon's output on
+	// purpose would otherwise just watch it stop, with nothing to search for.
+	fmt.Fprintln(os.Stderr, "deja daemon: stdio is a pipe and the daemon is long-lived; releasing it "+
+		"so the reader is not held open for the daemon's lifetime (redirect to a file to keep these logs)")
+
+	null, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		// Nothing safe to do: closing the descriptor outright would leave fd 1
+		// or 2 free for the next open to claim, and a stray write would then
+		// land in the database. Holding the pipe is the lesser failure.
+		return 0
+	}
+	defer null.Close()
+
+	released := 0
+	for _, f := range piped {
+		if err := dupOnto(int(null.Fd()), int(f.Fd())); err == nil {
+			released++
+		}
+	}
+	return released
+}
+
+// isPipe reports whether f is a pipe. Stat reports both anonymous pipes (a
+// command substitution, a shell pipeline) and named ones as ModeNamedPipe.
+func isPipe(f *os.File) bool {
+	fi, err := f.Stat()
+	return err == nil && fi.Mode()&os.ModeNamedPipe != 0
+}

--- a/cmd/deja/stdio_darwin.go
+++ b/cmd/deja/stdio_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package main
+
+import "syscall"
+
+// dupOnto makes newfd refer to oldfd's file, closing whatever newfd referred to
+// before. Darwin has no dup3; dup2 is the equivalent here.
+func dupOnto(oldfd, newfd int) error { return syscall.Dup2(oldfd, newfd) }

--- a/cmd/deja/stdio_linux.go
+++ b/cmd/deja/stdio_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package main
+
+import "syscall"
+
+// dupOnto makes newfd refer to oldfd's file, closing whatever newfd referred to
+// before, as one atomic step.
+//
+// Dup3 rather than Dup2: linux/arm64 has no dup2 syscall, and .goreleaser.yaml
+// builds linux/arm64.
+func dupOnto(oldfd, newfd int) error { return syscall.Dup3(oldfd, newfd, 0) }

--- a/cmd/deja/stdio_test.go
+++ b/cmd/deja/stdio_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestReleasePiped_ReaderSeesEOF is the regression test for #101.
+//
+// The daemon holds every descriptor it inherits for its whole lifetime. When
+// one of them is the write end of a command substitution's pipe, the shell
+// reading that pipe blocks until the daemon exits, which for a daemon means
+// "not today". The reproduction is exactly this: hold the write end, try to
+// read, and see whether the read ever returns.
+func TestReleasePiped_ReaderSeesEOF(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	if got := releasePiped(w); got != 1 {
+		t.Fatalf("releasePiped released %d descriptors, want 1", got)
+	}
+
+	// The write end is now /dev/null and the pipe has no writer left, so a read
+	// must return EOF rather than parking forever.
+	done := make(chan error, 1)
+	go func() {
+		_, err := r.Read(make([]byte, 1))
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != io.EOF {
+			t.Errorf("read returned %v, want EOF", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("reader is still blocked: a daemon spawned inside $(...) would hang its caller forever (#101)")
+	}
+}
+
+// A regular file must survive untouched, or `deja daemon 2>log` silently stops
+// collecting the logs it was pointed at.
+func TestReleasePiped_LeavesRegularFileAlone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.log")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+
+	if got := releasePiped(f); got != 0 {
+		t.Fatalf("releasePiped released %d descriptors for a regular file, want 0", got)
+	}
+
+	const line = "still logging\n"
+	if _, err := f.WriteString(line); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != line {
+		t.Errorf("log file holds %q, want %q; the descriptor was redirected away", got, line)
+	}
+}
+
+// isPipe drives the decision, so pin it on both kinds of descriptor directly.
+func TestIsPipe(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	f, err := os.Create(filepath.Join(t.TempDir(), "f"))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+
+	if !isPipe(r) || !isPipe(w) {
+		t.Error("isPipe does not recognise an anonymous pipe")
+	}
+	if isPipe(f) {
+		t.Error("isPipe treats a regular file as a pipe")
+	}
+}


### PR DESCRIPTION
Fixes #101.

Picking up @HaleTom's two questions at the bottom of that issue — the answer to the second one is yes, and it is not limited to `deja init`.

## What is actually happening

The daemon never detaches. It inherits whatever descriptors the caller had open and holds all of them for its entire lifetime. If one of them is the write end of a command substitution's pipe, the shell reading that pipe never sees EOF and waits forever — while the daemon sits there perfectly healthy, reparented to init, which is why the hung shell shows **zero child processes** and blocks in `anon_pipe_read`.

Deterministic reproduction, zsh 5.9 / Linux, no plugin manager involved:

```zsh
out=$( { deja daemon &! } 2>/dev/null; echo SPAWNED )
```

On `main` this never returns. With the fix it returns immediately, daemon still running in both cases.

The fd table of a daemon spawned that way shows the problem directly:

```
0 -> /dev/null      # only because the init script redirected
1 -> /dev/null
4 -> deja.db
7 -> socket:[...]
```

...and with the redirect removed, fds 1 and 2 are the caller's pipe, held open indefinitely.

`internal/shell/zsh.sh` does redirect on all four of its own spawn sites, which is why this is intermittent rather than constant — it only bites where something *else* spawns the daemon. That set is open-ended: a plugin-manager hook, a CI step, a hand-written `deja daemon &`, and — the one that matters most here — **an `init.zsh` cached from an older release**, which keeps doing whatever it did when it was written, long after the shipped script is fixed. That last case is why I do not think a shell-side change alone closes this.

## The fix

The daemon lets go itself, after startup has finished reporting and immediately before it blocks in `Serve`: any of stdin/stdout/stderr that is a *pipe* is pointed at `/dev/null`.

- A **terminal** is left alone, so `deja daemon` run by hand stays readable.
- A **regular file** is left alone, so `deja daemon 2>log` still collects logs.
- Only a pipe can deadlock a reader, so only a pipe is released.

Before releasing, it writes one line to stderr saying it is about to, so that someone who piped the output deliberately sees why it stopped instead of silence.

`dup3`/`dup2` is split by build tag: linux/arm64 has no `dup2` and darwin has no `dup3`, and `.goreleaser.yaml` builds both.

### Trade-off worth flagging

A `Serve` bind failure — most commonly "daemon already running" — is now invisible when stdio is a pipe, since the release happens just before it. That path exits immediately rather than blocking, so nothing hangs waiting to read it, and every earlier startup failure (db, state load, config) still reports normally. Happy to move the release behind a ready-callback from `Serve` instead if you would rather keep that message; it just needs a signature change I did not want to make unprompted.

## Testing

- `TestReleasePiped_ReaderSeesEOF` — holds a real pipe, releases it, asserts the reader gets `io.EOF` instead of parking. This is the regression test proper.
- `TestReleasePiped_LeavesRegularFileAlone` — `2>log` keeps working.
- `TestIsPipe` — pins the classification both ways.

`gofmt`, `go vet ./...`, `go test -race ./...` all pass. Cross-compiles clean for all four release targets (darwin/linux × amd64/arm64).

## What I did not reproduce

I could not set up @HaleTom's exact zinit configuration, so I have not confirmed *which* spawn inside a zinit update inherits the pipe. What I have confirmed is the mechanism, deterministically, and that it produces precisely the reported signature. If the hang persists for them after this lands, the remaining cause is a different one and worth reopening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
