### PR TITLE
fix: fall back to a short runtime socket path when $HOME makes it too long

### DIFF
--- a/cmd/deja/paths.go
+++ b/cmd/deja/paths.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 func dataDir() (string, error) {
@@ -59,10 +62,70 @@ func dbPath() (string, error) {
 	return filepath.Join(dir, "deja.db"), nil
 }
 
+// maxSockPath is the longest socket path safe to bind on any platform deja
+// releases for. sun_path is 108 bytes on Linux and 104 on macOS, both counting
+// the terminating NUL, so 103 is the largest length that works everywhere.
+const maxSockPath = 103
+
+// sockPath returns the daemon's socket path, next to the database unless that
+// would be too long to bind.
+//
+// bind(2) rejects an over-long path with EINVAL, which surfaces as
+// "bind: invalid argument" -- a message that names neither the limit nor the
+// cause. Worse, the daemon is normally spawned with output discarded, so the
+// user sees no error at all and deja simply appears inert. A $HOME deep enough
+// to trigger it is not exotic; a scratch or workspace path reaches 103 bytes
+// easily.
+//
+// Both the daemon and every client resolve the socket through this function,
+// so a deterministic fallback keeps them agreed without extra plumbing.
 func sockPath() (string, error) {
 	dir, err := dataDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, "sock"), nil
+	preferred := filepath.Join(dir, "sock")
+	if len(preferred) <= maxSockPath {
+		return preferred, nil
+	}
+	return runtimeSockPath(dir, preferred)
+}
+
+// runtimeSockPath places the socket in a short per-user runtime directory.
+//
+// Only a directory that is already per-user and owner-only qualifies:
+// $XDG_RUNTIME_DIR on Linux, and $TMPDIR on macOS, where it is per-user
+// (/var/folders/...) rather than shared. A plain /tmp fallback is deliberately
+// not attempted -- it is world-writable, and putting the socket there would
+// trade a loud failure for the squatting and symlink exposure that the 0700
+// parent directory otherwise rules out.
+//
+// The name is derived from the data directory so two accounts, or two $HOMEs
+// belonging to one account, never collide on a shared runtime directory.
+func runtimeSockPath(dataDirPath, preferred string) (string, error) {
+	base := os.Getenv("XDG_RUNTIME_DIR")
+	if base == "" && runtime.GOOS == "darwin" {
+		base = os.Getenv("TMPDIR")
+	}
+	if base == "" {
+		return "", fmt.Errorf(
+			"socket path %s is %d bytes, over the %d-byte limit for a unix socket, "+
+				"and no per-user runtime directory is available to fall back to "+
+				"(set XDG_RUNTIME_DIR, or use a shorter HOME)",
+			preferred, len(preferred), maxSockPath)
+	}
+
+	sum := sha256.Sum256([]byte(dataDirPath))
+	dir := filepath.Join(base, "deja")
+	if err := ensurePrivateDir(dir); err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, hex.EncodeToString(sum[:4])+".sock")
+	if len(path) > maxSockPath {
+		return "", fmt.Errorf(
+			"socket path %s is %d bytes, over the %d-byte limit for a unix socket, "+
+				"and the fallback under %s is too long as well",
+			preferred, len(preferred), maxSockPath, base)
+	}
+	return path, nil
 }

--- a/cmd/deja/paths_test.go
+++ b/cmd/deja/paths_test.go
@@ -95,6 +95,24 @@ func TestDataDir_RepairsExistingLooseDir(t *testing.T) {
 	}
 }
 
+// shortTempDir returns a temporary directory short enough to leave room for a
+// unix socket beneath it.
+//
+// t.TempDir embeds the test's own name in the path. Under macOS's $TMPDIR
+// (/var/folders/<...>/T/, 49 bytes before anything else) a descriptive test
+// name pushes the result past sun_path, so these fixtures failed on the fixture
+// rather than on the code. os.MkdirTemp omits the name, which is what
+// internal/daemon's shortSockPath already relies on.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "deja")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
 // longHome returns a $HOME deep enough that the socket beside the database
 // would exceed sun_path, built under root so it is still a real directory.
 func longHome(t *testing.T, root string) string {
@@ -113,15 +131,21 @@ func longHome(t *testing.T, root string) string {
 // fallback must not fire for a normal $HOME, or every existing install would
 // silently move its socket and lose its running daemon.
 func TestSockPath_ShortHomeKeepsSocketBesideDatabase(t *testing.T) {
-	home := t.TempDir()
+	home := shortTempDir(t)
 	t.Setenv("HOME", home)
-	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("XDG_RUNTIME_DIR", shortTempDir(t))
+
+	// Name the fixture if it ever grows too long itself, rather than failing the
+	// assertion below and pointing at the code.
+	want := filepath.Join(home, ".local", "share", "deja", "sock")
+	if len(want) > maxSockPath {
+		t.Fatalf("fixture home is too long (%d bytes) to exercise the ordinary case", len(want))
+	}
 
 	got, err := sockPath()
 	if err != nil {
 		t.Fatalf("sockPath: %v", err)
 	}
-	want := filepath.Join(home, ".local", "share", "deja", "sock")
 	if got != want {
 		t.Errorf("sockPath = %q, want %q", got, want)
 	}
@@ -131,8 +155,8 @@ func TestSockPath_ShortHomeKeepsSocketBesideDatabase(t *testing.T) {
 // bug. Asserting on the length alone would pass for a path that still cannot be
 // bound, so this binds it — the operation that actually failed with EINVAL.
 func TestSockPath_LongHomeProducesABindableSocket(t *testing.T) {
-	t.Setenv("HOME", longHome(t, t.TempDir()))
-	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("HOME", longHome(t, shortTempDir(t)))
+	t.Setenv("XDG_RUNTIME_DIR", shortTempDir(t))
 
 	got, err := sockPath()
 	if err != nil {
@@ -152,8 +176,8 @@ func TestSockPath_LongHomeProducesABindableSocket(t *testing.T) {
 // The fallback directory holds a socket into the command-history daemon, so it
 // must be owner-only like the data directory it stands in for.
 func TestSockPath_FallbackDirectoryIsOwnerOnly(t *testing.T) {
-	t.Setenv("HOME", longHome(t, t.TempDir()))
-	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("HOME", longHome(t, shortTempDir(t)))
+	t.Setenv("XDG_RUNTIME_DIR", shortTempDir(t))
 
 	got, err := sockPath()
 	if err != nil {
@@ -171,11 +195,11 @@ func TestSockPath_FallbackDirectoryIsOwnerOnly(t *testing.T) {
 // Two accounts sharing one runtime directory must not land on the same socket,
 // or one daemon answers the other's shells out of the wrong history.
 func TestSockPath_FallbackIsPerDataDirectory(t *testing.T) {
-	runtimeDir := t.TempDir()
+	runtimeDir := shortTempDir(t)
 
 	paths := make([]string, 2)
 	for i := range paths {
-		t.Setenv("HOME", longHome(t, t.TempDir()))
+		t.Setenv("HOME", longHome(t, shortTempDir(t)))
 		t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 		p, err := sockPath()
 		if err != nil {
@@ -191,8 +215,8 @@ func TestSockPath_FallbackIsPerDataDirectory(t *testing.T) {
 // The same home must resolve to the same socket on every call, or the daemon
 // and its clients would disagree about where to meet.
 func TestSockPath_FallbackIsStable(t *testing.T) {
-	t.Setenv("HOME", longHome(t, t.TempDir()))
-	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("HOME", longHome(t, shortTempDir(t)))
+	t.Setenv("XDG_RUNTIME_DIR", shortTempDir(t))
 
 	first, err := sockPath()
 	if err != nil {
@@ -214,7 +238,7 @@ func TestSockPath_WithoutRuntimeDirExplainsItself(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Setenv("TMPDIR", "")
 	}
-	t.Setenv("HOME", longHome(t, t.TempDir()))
+	t.Setenv("HOME", longHome(t, shortTempDir(t)))
 	t.Setenv("XDG_RUNTIME_DIR", "")
 
 	_, err := sockPath()

--- a/cmd/deja/paths_test.go
+++ b/cmd/deja/paths_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"net"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -89,5 +92,138 @@ func TestDataDir_RepairsExistingLooseDir(t *testing.T) {
 	}
 	if perm := info.Mode().Perm(); perm != 0o700 {
 		t.Errorf("existing dir was not repaired: mode %04o, want 0700", perm)
+	}
+}
+
+// longHome returns a $HOME deep enough that the socket beside the database
+// would exceed sun_path, built under root so it is still a real directory.
+func longHome(t *testing.T, root string) string {
+	t.Helper()
+	home := root
+	for len(filepath.Join(home, ".local", "share", "deja", "sock")) <= maxSockPath {
+		home = filepath.Join(home, "deeper-than-you-would-think")
+	}
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir long home: %v", err)
+	}
+	return home
+}
+
+// TestSockPath_ShortHomeKeepsSocketBesideDatabase pins the ordinary case: the
+// fallback must not fire for a normal $HOME, or every existing install would
+// silently move its socket and lose its running daemon.
+func TestSockPath_ShortHomeKeepsSocketBesideDatabase(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	got, err := sockPath()
+	if err != nil {
+		t.Fatalf("sockPath: %v", err)
+	}
+	want := filepath.Join(home, ".local", "share", "deja", "sock")
+	if got != want {
+		t.Errorf("sockPath = %q, want %q", got, want)
+	}
+}
+
+// TestSockPath_LongHomeProducesABindableSocket is the regression test for the
+// bug. Asserting on the length alone would pass for a path that still cannot be
+// bound, so this binds it — the operation that actually failed with EINVAL.
+func TestSockPath_LongHomeProducesABindableSocket(t *testing.T) {
+	t.Setenv("HOME", longHome(t, t.TempDir()))
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	got, err := sockPath()
+	if err != nil {
+		t.Fatalf("sockPath: %v", err)
+	}
+	if len(got) > maxSockPath {
+		t.Fatalf("sockPath returned %d bytes (%q), over the %d-byte limit", len(got), got, maxSockPath)
+	}
+
+	l, err := net.Listen("unix", got)
+	if err != nil {
+		t.Fatalf("the returned path could not be bound, which is the whole bug: %v", err)
+	}
+	l.Close()
+}
+
+// The fallback directory holds a socket into the command-history daemon, so it
+// must be owner-only like the data directory it stands in for.
+func TestSockPath_FallbackDirectoryIsOwnerOnly(t *testing.T) {
+	t.Setenv("HOME", longHome(t, t.TempDir()))
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	got, err := sockPath()
+	if err != nil {
+		t.Fatalf("sockPath: %v", err)
+	}
+	info, err := os.Stat(filepath.Dir(got))
+	if err != nil {
+		t.Fatalf("stat fallback dir: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("fallback directory has mode %04o, want 0700", perm)
+	}
+}
+
+// Two accounts sharing one runtime directory must not land on the same socket,
+// or one daemon answers the other's shells out of the wrong history.
+func TestSockPath_FallbackIsPerDataDirectory(t *testing.T) {
+	runtimeDir := t.TempDir()
+
+	paths := make([]string, 2)
+	for i := range paths {
+		t.Setenv("HOME", longHome(t, t.TempDir()))
+		t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+		p, err := sockPath()
+		if err != nil {
+			t.Fatalf("sockPath: %v", err)
+		}
+		paths[i] = p
+	}
+	if paths[0] == paths[1] {
+		t.Errorf("two different homes share socket %q", paths[0])
+	}
+}
+
+// The same home must resolve to the same socket on every call, or the daemon
+// and its clients would disagree about where to meet.
+func TestSockPath_FallbackIsStable(t *testing.T) {
+	t.Setenv("HOME", longHome(t, t.TempDir()))
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	first, err := sockPath()
+	if err != nil {
+		t.Fatalf("sockPath: %v", err)
+	}
+	second, err := sockPath()
+	if err != nil {
+		t.Fatalf("sockPath: %v", err)
+	}
+	if first != second {
+		t.Errorf("sockPath is not stable: %q then %q", first, second)
+	}
+}
+
+// With no runtime directory to fall back to there is nothing safe left to try,
+// but the error must still name the limit and the way out — the whole point is
+// that "bind: invalid argument" did neither.
+func TestSockPath_WithoutRuntimeDirExplainsItself(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Setenv("TMPDIR", "")
+	}
+	t.Setenv("HOME", longHome(t, t.TempDir()))
+	t.Setenv("XDG_RUNTIME_DIR", "")
+
+	_, err := sockPath()
+	if err == nil {
+		t.Fatal("expected an error when no runtime directory is available")
+	}
+	for _, want := range []string{"unix socket", "XDG_RUNTIME_DIR", "shorter HOME"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #106.

## The problem

The socket sits beside the database under `$HOME`, and `sun_path` is 108 bytes on Linux, 104 on macOS. A deep enough home pushes it over and `bind(2)` returns `EINVAL`:

```
deja daemon: listen .../.local/share/deja/sock: listen unix .../sock: bind: invalid argument
```

Two things make that worse than a plain error. The message names neither the limit nor the cause, and `_deja_ensure_daemon` spawns the daemon with `>/dev/null 2>&1`, so nobody ever sees it — deja simply does nothing, with no clue why. I hit this running deja from a scratch directory, not from a constructed pathological path.

## The fix

`sockPath()` keeps the socket beside the database whenever it fits — unchanged for every normal install, which matters, since moving it would strand running daemons. Only when it would not fit does it fall back to a short per-user runtime directory:

- **Linux**: `$XDG_RUNTIME_DIR`, already per-user and 0700
- **macOS**: `$TMPDIR`, which is per-user there (`/var/folders/...`) rather than shared

The socket is named from a SHA-256 prefix of the data directory, so two homes sharing one runtime directory cannot collide, and the mapping is stable — the daemon and every client resolve through this same function and must agree on where to meet.

### What it deliberately does not do

No `/tmp` fallback. `/tmp` is world-writable, and putting a socket into the command-history daemon there would trade a loud failure for exactly the squatting and symlink exposure that the 0700 parent directory currently rules out — which is the same reasoning behind #77/#79.

That leaves one case still failing: a long `$HOME` with no per-user runtime directory available. It now fails with

```
socket path ... is 118 bytes, over the 103-byte limit for a unix socket, and no
per-user runtime directory is available to fall back to (set XDG_RUNTIME_DIR, or
use a shorter HOME)
```

I would rather say that plainly than reach for an unsafe directory. If you would prefer a guarded `/tmp` fallback as well, I am happy to add it.

## Testing

Six tests in `cmd/deja/paths_test.go`. The important one **binds** the returned path rather than measuring it, since a length assertion would pass for a path that still cannot be bound — binding is the operation that actually failed:

- `TestSockPath_LongHomeProducesABindableSocket` — the regression test
- `TestSockPath_ShortHomeKeepsSocketBesideDatabase` — no silent migration for existing installs
- `TestSockPath_FallbackDirectoryIsOwnerOnly` — 0700, like the data directory
- `TestSockPath_FallbackIsPerDataDirectory` / `_FallbackIsStable` — no collisions, stable mapping
- `TestSockPath_WithoutRuntimeDirExplainsItself` — the error names the limit and the way out

`gofmt`, `go vet ./...`, `go test -race ./...` all pass; cross-compiles clean for darwin/linux × amd64/arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
