### PR TITLE
fix: do not signal a pid from a stale pidfile in daemon --restart

### DIFF
--- a/cmd/deja/daemon.go
+++ b/cmd/deja/daemon.go
@@ -111,6 +111,19 @@ func runDaemon(args []string) {
 func stopRunningDaemon(sock string) error {
 	pidPath := daemon.PidPath(sock)
 
+	// Ask the socket before trusting the pidfile. The file is removed on a clean
+	// exit, so one that outlives its daemon means the process was killed or the
+	// machine went down -- and by then the kernel may well have recycled that pid
+	// onto something unrelated, which runs under the same uid and would take the
+	// SIGTERM below without complaint. Nothing is listening in that case, so
+	// treat "no answer" as stale state to clear rather than as a target to
+	// signal.
+	if !daemon.IsLiveSocket(sock, daemon.ProbeTimeout) {
+		os.Remove(pidPath)
+		os.Remove(sock)
+		return nil
+	}
+
 	raw, err := os.ReadFile(pidPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/deja/restart_test.go
+++ b/cmd/deja/restart_test.go
@@ -14,6 +14,23 @@ import (
 	"github.com/giammarcoferranti/deja/internal/daemon"
 )
 
+// shortSockPath returns a socket path short enough to bind.
+//
+// t.TempDir embeds the test's own name in the path. Under macOS $TMPDIR
+// (/var/folders/<...>/T/, 49 bytes before anything else) a descriptive test
+// name pushes the result past sun_path, which holds 104 bytes there against
+// 108 on Linux. os.MkdirTemp omits the name; this mirrors the helper of the
+// same name in internal/daemon, which exists for exactly this reason.
+func shortSockPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "deja")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "s")
+}
+
 // answerPing listens on sock and replies to the liveness probe, standing in for
 // a serving daemon. A real one would need a database and loaded state; the
 // probe only looks for a pong, and the branch under test only asks the probe.
@@ -53,7 +70,7 @@ func answerPing(t *testing.T, sock string) {
 // The setup is that state exactly: a live process that is not deja, a pidfile
 // naming it, and nothing listening.
 func TestStopRunningDaemon_LeavesAnUnrelatedProcessAlone(t *testing.T) {
-	sock := filepath.Join(t.TempDir(), "sock")
+	sock := shortSockPath(t)
 
 	standIn := exec.Command("sleep", "60")
 	if err := standIn.Start(); err != nil {
@@ -104,7 +121,7 @@ func TestStopRunningDaemon_LeavesAnUnrelatedProcessAlone(t *testing.T) {
 // existing "listening but wrote no pidfile" error. Reaching it proves the
 // liveness probe said yes and the function did not short-circuit.
 func TestStopRunningDaemon_ActsOnALiveDaemon(t *testing.T) {
-	sock := filepath.Join(t.TempDir(), "sock")
+	sock := shortSockPath(t)
 	answerPing(t, sock)
 
 	if !daemon.IsLiveSocket(sock, daemon.ProbeTimeout) {
@@ -122,7 +139,7 @@ func TestStopRunningDaemon_ActsOnALiveDaemon(t *testing.T) {
 
 // Nothing running and nothing left behind must stay a silent no-op.
 func TestStopRunningDaemon_NoDaemonIsANoOp(t *testing.T) {
-	sock := filepath.Join(t.TempDir(), "sock")
+	sock := shortSockPath(t)
 	if err := stopRunningDaemon(sock); err != nil {
 		t.Errorf("stopRunningDaemon on a cold machine returned %v, want nil", err)
 	}

--- a/cmd/deja/restart_test.go
+++ b/cmd/deja/restart_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/giammarcoferranti/deja/internal/daemon"
+)
+
+// answerPing listens on sock and replies to the liveness probe, standing in for
+// a serving daemon. A real one would need a database and loaded state; the
+// probe only looks for a pong, and the branch under test only asks the probe.
+func answerPing(t *testing.T, sock string) {
+	t.Helper()
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen %s: %v", sock, err)
+	}
+	t.Cleanup(func() { l.Close() })
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				var env daemon.Envelope
+				if json.NewDecoder(c).Decode(&env) != nil {
+					return
+				}
+				json.NewEncoder(c).Encode(daemon.PingResp{Pong: true})
+			}(conn)
+		}
+	}()
+}
+
+// TestStopRunningDaemon_LeavesAnUnrelatedProcessAlone is the regression test.
+//
+// The pidfile is removed with a defer, so it survives SIGKILL, an OOM kill or a
+// power loss. What is left names a pid deja no longer owns, and pids get
+// recycled — so `deja daemon --restart` would SIGTERM whatever inherited the
+// number, under the user's own uid, where permissions do not stop it.
+//
+// The setup is that state exactly: a live process that is not deja, a pidfile
+// naming it, and nothing listening.
+func TestStopRunningDaemon_LeavesAnUnrelatedProcessAlone(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "sock")
+
+	standIn := exec.Command("sleep", "60")
+	if err := standIn.Start(); err != nil {
+		t.Fatalf("start stand-in process: %v", err)
+	}
+	pid := standIn.Process.Pid
+
+	// Watch for the process ending via Wait, not via kill(pid, 0). A signalled
+	// child becomes a zombie until it is reaped, and signal 0 still succeeds
+	// against a zombie -- so the obvious liveness check would report the victim
+	// as alive and the test would pass while the bug fired.
+	exited := make(chan struct{})
+	go func() {
+		standIn.Wait()
+		close(exited)
+	}()
+	t.Cleanup(func() {
+		standIn.Process.Kill()
+		<-exited
+	})
+
+	pidPath := daemon.PidPath(sock)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)), 0o600); err != nil {
+		t.Fatalf("write pidfile: %v", err)
+	}
+
+	if err := stopRunningDaemon(sock); err != nil {
+		t.Fatalf("stopRunningDaemon: %v", err)
+	}
+
+	// Give a delivered signal time to land and be reaped, so a pass cannot come
+	// from looking too early.
+	select {
+	case <-exited:
+		t.Errorf("stopRunningDaemon signalled pid %d, which was not the daemon", pid)
+	case <-time.After(500 * time.Millisecond):
+	}
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Error("stale pidfile left in place; the next --restart would read it again")
+	}
+}
+
+// The other half of the contract. A "fix" that never signals anything would
+// pass the test above, so this pins that a live daemon is still acted on.
+//
+// It asserts via the no-pidfile branch rather than by killing anything: with the
+// socket answering and no pidfile present, stopRunningDaemon must reach the
+// existing "listening but wrote no pidfile" error. Reaching it proves the
+// liveness probe said yes and the function did not short-circuit.
+func TestStopRunningDaemon_ActsOnALiveDaemon(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "sock")
+	answerPing(t, sock)
+
+	if !daemon.IsLiveSocket(sock, daemon.ProbeTimeout) {
+		t.Fatal("stand-in daemon is not answering; the test would prove nothing")
+	}
+
+	err := stopRunningDaemon(sock)
+	if err == nil {
+		t.Fatal("expected the no-pidfile error for a live daemon, got nil — the live branch was skipped")
+	}
+	if !strings.Contains(err.Error(), "wrote no pidfile") {
+		t.Errorf("unexpected error %q; wanted the live-daemon-without-pidfile path", err)
+	}
+}
+
+// Nothing running and nothing left behind must stay a silent no-op.
+func TestStopRunningDaemon_NoDaemonIsANoOp(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "sock")
+	if err := stopRunningDaemon(sock); err != nil {
+		t.Errorf("stopRunningDaemon on a cold machine returned %v, want nil", err)
+	}
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -284,7 +284,7 @@ func TestServe_RefusesWhenLiveDaemonPresent(t *testing.T) {
 		t.Fatalf("want 'already running' error from second Serve, got %v", err)
 	}
 
-	if !isLiveSocket(sockPath, 200*time.Millisecond) {
+	if !IsLiveSocket(sockPath, 200*time.Millisecond) {
 		t.Fatal("daemon A stopped responding after second Serve attempt — its socket was clobbered")
 	}
 
@@ -300,7 +300,7 @@ func waitForPing(t *testing.T, sockPath string, timeout time.Duration) bool {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if isLiveSocket(sockPath, 100*time.Millisecond) {
+		if IsLiveSocket(sockPath, 100*time.Millisecond) {
 			return true
 		}
 		time.Sleep(20 * time.Millisecond)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -16,7 +16,9 @@ import (
 
 const (
 	connDeadline = 2 * time.Second
-	probeTimeout = 50 * time.Millisecond
+	// ProbeTimeout bounds the liveness probe. Exported alongside IsLiveSocket so
+	// callers outside this package ask the same question with the same bound.
+	ProbeTimeout = 50 * time.Millisecond
 
 	// checkpointInterval is how often the WAL is truncated. See checkpointLoop
 	// for why it is long rather than eager.
@@ -36,11 +38,11 @@ func PidPath(sockPath string) string {
 //
 // If the initial bind fails, Serve probes the existing socket: a live daemon
 // (one that answers ping) is left alone and Serve returns an error; a stale
-// file (no answer within probeTimeout) is removed and bind is retried once.
+// file (no answer within ProbeTimeout) is removed and bind is retried once.
 func Serve(ctx context.Context, state *State, sockPath string) error {
 	l, err := net.Listen("unix", sockPath)
 	if err != nil {
-		if isLiveSocket(sockPath, probeTimeout) {
+		if IsLiveSocket(sockPath, ProbeTimeout) {
 			return fmt.Errorf("daemon already running at %s", sockPath)
 		}
 		if rmErr := os.Remove(sockPath); rmErr != nil && !os.IsNotExist(rmErr) {
@@ -92,10 +94,13 @@ func Serve(ctx context.Context, state *State, sockPath string) error {
 	}
 }
 
-// isLiveSocket reports whether sockPath has a daemon currently answering ping
+// IsLiveSocket reports whether sockPath has a daemon currently answering ping
 // within timeout. Any failure (dial error, no/garbled response, Pong=false) is
 // treated as not-live so the caller can clear a stale file and rebind.
-func isLiveSocket(sockPath string, timeout time.Duration) bool {
+//
+// Exported because it is also the only portable way to tell a daemon that is
+// still serving from a pidfile that merely outlived one: see stopRunningDaemon.
+func IsLiveSocket(sockPath string, timeout time.Duration) bool {
 	conn, err := net.DialTimeout("unix", sockPath, timeout)
 	if err != nil {
 		return false


### PR DESCRIPTION
Fixes #108.

## The problem

`stopRunningDaemon` signalled whatever pid the pidfile named:

```go
pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
...
if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
```

`ESRCH` is handled — a pid that no longer exists is treated as stale. The case that matters is the other one: the pid **existing and belonging to something else**.

The pidfile is removed with `defer os.Remove(pidPath)`, so it survives anything that skips deferred cleanup: `SIGKILL`, an OOM kill, a power loss. What is left names a pid deja no longer owns, and pids get recycled. The next `deja daemon --restart` then terminates whoever inherited the number — under the user's own uid, so permissions do not stop it.

## The fix

A pidfile only names a daemon while one is actually serving, so ask the socket before trusting it. `isLiveSocket` already exists for exactly this question; it is now exported as `IsLiveSocket`, alongside `ProbeTimeout` so callers outside the package ask with the same bound.

A crashed daemon leaves a socket that refuses connections, so "no answer" means stale state to clear rather than a target to signal. This keeps the check portable — reading `/proc/<pid>` would not work on macOS.

### Residual case, stated plainly

Daemon A is live while the pidfile is a stale entry from crashed daemon B whose pid was reused. The existing post-signal wait already catches that and reports the socket was not released, so the outcome is a clear error rather than silence. A `flock` on the pidfile held for the daemon's lifetime would close it properly; I did not reach for that because it is a new mechanism for a much narrower case, but I am happy to if you would prefer it.

## Testing

`cmd/deja/restart_test.go`:

- `TestStopRunningDaemon_LeavesAnUnrelatedProcessAlone` — the regression test. A live non-deja process, a pidfile naming it, nothing listening.
- `TestStopRunningDaemon_ActsOnALiveDaemon` — the other half, so a "fix" that simply never signals anything cannot pass. It asserts via the existing "listening but wrote no pidfile" branch rather than by killing anything.
- `TestStopRunningDaemon_NoDaemonIsANoOp` — a cold machine stays silent.

Worth flagging one thing I got wrong first, in case it saves someone else the trap: I originally checked survival with `kill(pid, 0)`, which **passes against a zombie**. The victim was a direct child, so after SIGTERM it sat unreaped and the test passed while the bug fired. It now observes termination through `Wait` instead. Verified failing for the right reason with the fix reverted:

```
--- FAIL: TestStopRunningDaemon_LeavesAnUnrelatedProcessAlone
    restart_test.go:91: stopRunningDaemon signalled pid 2945447, which was not the daemon
```

`gofmt`, `go vet ./...`, `go test -race ./...` all pass (including the two existing `internal/daemon` tests updated for the rename); cross-compiles clean for darwin/linux × amd64/arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
