### PR TITLE
perf: resolve the redraw hook's add-zle-hook-widget probe once per shell

### DIFF
--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -159,6 +159,96 @@ func TestZshInit_InstallsRedrawHook(t *testing.T) {
 	}
 }
 
+// TestZshInit_RedrawHookProbeMemoized pins the shape of the availability probe.
+// _deja_install_redraw_hook runs on every precmd, so whatever it does to decide
+// whether add-zle-hook-widget exists is paid before every prompt. It used to
+// glob `${^fpath}/add-zle-hook-widget(N)`, which touches every $fpath entry on
+// every call; on the first shell after a boot, with nothing in the page cache
+// and a zinit-sized $fpath, that measured 137ms of startup (#111). The live test
+// below proves the behavior; these assertions catch a silent regression if
+// someone reintroduces a per-call search.
+func TestZshInit_RedrawHookProbeMemoized(t *testing.T) {
+	script := ZshInit()
+
+	if strings.Contains(script, "${^fpath}") {
+		t.Error("init script globs every $fpath entry; the redraw-hook probe must not re-scan $fpath per call")
+	}
+	if !strings.Contains(script, "typeset -gi _DEJA_REDRAW_HOOK_AVAILABLE=-1") {
+		t.Error("_DEJA_REDRAW_HOOK_AVAILABLE is not declared; the probe would run on every precmd")
+	}
+	// +X resolves the function now and reports a miss as a non-zero status. A
+	// plain `autoload` defers both, so a missing file surfaces as an error on the
+	// user's first keystroke instead of a clean fall back to the old behavior.
+	if !strings.Contains(script, "autoload -Uz +X add-zle-hook-widget") {
+		t.Error("probe does not use `autoload -Uz +X`; a missing definition file would go undetected until first call")
+	}
+}
+
+// TestZshInit_RedrawHookProbeBehavior proves the contract the memoized probe has
+// to keep: the hook still registers, re-registering stays a no-op across
+// precmds, and a shell that genuinely lacks add-zle-hook-widget degrades
+// quietly rather than leaving a stub that cannot load.
+func TestZshInit_RedrawHookProbeBehavior(t *testing.T) {
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh not installed; skipping behavior check")
+	}
+
+	// DEJA_BIN must be executable or the startup tail skips binding entirely;
+	// /bin/true is a harmless stand-in that spawns no daemon.
+	script := strings.ReplaceAll(ZshInit(), "{{DEJA_BIN}}", "/usr/bin/true")
+	script = strings.ReplaceAll(script, "{{DEJA_SOCK}}", "/nonexistent/sock")
+	script = strings.ReplaceAll(script, "{{DEJA_BIN_STAMP}}", "")
+	path := filepath.Join(t.TempDir(), "init.zsh")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	prog := `
+		source ` + path + ` >/dev/null 2>&1
+
+		print -r -- "probe:$_DEJA_REDRAW_HOOK_AVAILABLE"
+		hooked() { add-zle-hook-widget -L zle-line-pre-redraw 2>/dev/null | grep -c _deja_line_pre_redraw }
+		print -r -- "installed:$(hooked)"
+
+		# Three more precmds' worth of calls must not stack the hook.
+		_deja_install_redraw_hook
+		_deja_install_redraw_hook
+		_deja_install_redraw_hook
+		print -r -- "afterprecmds:$(hooked)"
+
+		# A shell where add-zle-hook-widget cannot be found at all.
+		unfunction add-zle-hook-widget 2>/dev/null
+		fpath=()
+		_DEJA_REDRAW_HOOK_AVAILABLE=-1
+		_deja_install_redraw_hook && print -r -- "missing:installed" || print -r -- "missing:declined"
+		print -r -- "cached:$_DEJA_REDRAW_HOOK_AVAILABLE"
+		print -r -- "stub:${+functions[add-zle-hook-widget]}"
+	`
+	out, err := exec.Command(zsh, "-f", "-c", prog).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run: %v\n%s", err, out)
+	}
+
+	got := strings.Fields(string(out))
+	want := []string{
+		"probe:1",          // resolved once, at startup
+		"installed:1",      // hook is on the chain
+		"afterprecmds:1",   // and re-registering did not stack it
+		"missing:declined", // no add-zle-hook-widget: return non-zero
+		"cached:0",         // and remember that, so precmd stops searching
+		"stub:0",           // leaving no autoload stub that cannot load
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines %q, want %d %q", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d: got %q, want %q", i+1, got[i], want[i])
+		}
+	}
+}
+
 // TestZshInit_IgnoresHookAliases covers a sharp edge in add-zle-hook-widget: it
 // preserves an incumbent hook by aliasing it to a name like
 // `user:_deja_line_init`, which matches none of the other ignore patterns. Left

--- a/internal/shell/zsh.sh
+++ b/internal/shell/zsh.sh
@@ -1158,12 +1158,41 @@ _deja_line_pre_redraw() {
 # (unlike the `zle -N` chaining zle-line-init needs). Where the function is
 # unavailable (pre-5.3, trimmed fpath) deja keeps its old behavior: the ghost is
 # painted, just not repaired after an unwrapped widget rewrites the line.
-_deja_install_redraw_hook() {
-	local -a azhw
-	azhw=(${^fpath}/add-zle-hook-widget(N))
-	(( $#azhw || ${+functions[add-zle-hook-widget]} )) || return 1
 
-	autoload -Uz add-zle-hook-widget
+# Whether add-zle-hook-widget can be used, resolved once per shell: -1 not yet
+# probed, 1 available, 0 not.
+#
+# Deciding it costs an $fpath search, and _deja_install_redraw_hook runs on every
+# precmd, so an unmemoized probe repeats that search before every prompt. The
+# cost is linear in $#fpath: ~0.0033ms per entry once the page cache is warm, but
+# every entry is a cold directory access in the first shell after a boot, which
+# is how a zinit-sized $fpath turned this into 137ms of startup (#111).
+#
+# Caching the negative answer means an add-zle-hook-widget that appears in $fpath
+# later in the session is not picked up; re-sourcing deja's init re-runs the
+# probe, and the alternative is paying for the search before every prompt.
+typeset -gi _DEJA_REDRAW_HOOK_AVAILABLE=-1
+
+_deja_install_redraw_hook() {
+	if (( _DEJA_REDRAW_HOOK_AVAILABLE < 0 )); then
+		# `autoload +X` searches $fpath and loads the definition immediately,
+		# reporting a miss as a non-zero status rather than deferring it to an
+		# error on the user's first keystroke. It stops at the first hit, where
+		# the glob this replaced visited every entry, and it loads the function
+		# that is about to be called anyway.
+		if (( ${+functions[add-zle-hook-widget]} )); then
+			_DEJA_REDRAW_HOOK_AVAILABLE=1
+		elif autoload -Uz +X add-zle-hook-widget 2>/dev/null; then
+			_DEJA_REDRAW_HOOK_AVAILABLE=1
+		else
+			# A failed +X still leaves the autoload marker behind. Drop it so
+			# nothing else in the shell inherits a stub that cannot load.
+			unfunction add-zle-hook-widget 2>/dev/null
+			_DEJA_REDRAW_HOOK_AVAILABLE=0
+		fi
+	fi
+
+	(( _DEJA_REDRAW_HOOK_AVAILABLE )) || return 1
 	add-zle-hook-widget zle-line-pre-redraw _deja_line_pre_redraw
 }
 


### PR DESCRIPTION
Fixes #111.

## What is slow

`_deja_install_redraw_hook` decides whether `add-zle-hook-widget` is usable by globbing every `$fpath` entry:

```zsh
azhw=(${^fpath}/add-zle-hook-widget(N))
```

Two things make that expensive:

1. **It visits every entry** instead of stopping at the first hit, so the cost is linear in `$#fpath` — and a zinit setup has a long one.
2. **It runs on every precmd**, not just at startup. `_deja_install_redraw_hook` is in the precmd rebind block next to `_deja_apply_keybindings`, so the whole search is repeated before every prompt.

Warm, the per-entry cost is ~0.0033ms and none of this is visible. In the **first shell after a boot** nothing in `$fpath` is in the page cache yet and every entry is a real directory access — which is how @Wateir's profile shows `_deja_install_redraw_hook` at **136.97ms self time, 44% of startup**.

Worth noting the report understates the reach: that config sets `DEJA_MANUAL_REBIND=1`, which skips the precmd rebind block entirely, so it pays the scan **once**. Without that variable it is paid **before every prompt**.

## The fix

Probe once per shell and remember the answer.

`autoload -Uz +X` performs the same `$fpath` lookup the subsequent call would trigger anyway, but it resolves immediately and reports a miss as a non-zero status instead of deferring it to a "function definition file not found" error on the user's first keystroke. It also stops at the first hit.

Startup goes from two `$fpath` passes (glob-all, then the deferred autoload) to one. Every later prompt does none.

## Measurements

Synthetic `$fpath`, warm page cache, zsh 5.9 — cost of `_deja_install_redraw_hook` per prompt:

| `$fpath` entries | before | after |
|---:|---:|---:|
| 21 | 0.1450 ms | 0.0595 ms |
| 41 | 0.2331 ms | 0.0576 ms |
| 81 | 0.3313 ms | 0.0601 ms |

Linear → constant. The residual ~0.06ms is `add-zle-hook-widget`'s own idempotent re-registration, which this change does not touch.

Isolating the startup call at 31 entries: **0.2655 ms → 0.1337 ms**, the two-passes-to-one saving.

## Trade-off

Caching the *negative* answer means an `add-zle-hook-widget` that appears in `$fpath` later in the session is not picked up. `add-zle-hook-widget` ships with zsh itself, so it is present from the first prompt in any normal setup; re-sourcing deja's init re-probes if it ever is not. The alternative is paying for the search before every prompt, which is the bug.

## Tests

- `TestZshInit_RedrawHookProbeMemoized` — pins the mechanism: no `${^fpath}` glob remains, the memo global is declared, `autoload -Uz +X` is used.
- `TestZshInit_RedrawHookProbeBehavior` — live zsh: the hook still registers, three further precmd-style calls do not stack it, and a shell with no `add-zle-hook-widget` declines quietly, caches that, and leaves no autoload stub behind.

Both fail against the current `zsh.sh` and pass with the change. Existing `TestZshInit_InstallsRedrawHook` is unaffected.

`go test -race ./...` and `go vet ./...` both pass.
