### PR TITLE
fix: anchor suggestions to the command you typed

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ score = 1.0 × fuzzy
 | **Directory affinity** | How often you've run this command from the current directory |
 | **Sequence score** | Probability that this command follows the one you just ran |
 
+### Anchoring
+
+Scoring only runs over commands that are plausible continuations of what you typed. If any command in your history starts with the text on the line, only those are considered — typing `cd ` suggests a `cd …` you have actually run, never `claude --resume` just because `c…d…␣` happens to be hiding in it. If nothing starts with the line but its first word is a command you've run, the suggestion stays inside that command, so `git ceckout` still finds `git checkout main`.
+
+Fuzzy expansion applies when the text is *not* a command you've run: `gco` → `git checkout` is untouched. The flip side is that an anchored line with nothing to match shows no ghost text at all, rather than an unrelated command.
+
 ### Architecture
 
 ```

--- a/internal/scorer/scorer.go
+++ b/internal/scorer/scorer.go
@@ -208,6 +208,59 @@ type candidateSource []store.CommandStat
 func (c candidateSource) String(i int) string { return c[i].Command }
 func (c candidateSource) Len() int            { return len(c) }
 
+// anchor restricts candidates to continuations of the buffer: fuzzy matching
+// alone reads `cd ` as a subsequence of `claude --resume`. Zero value = no-op.
+type anchor struct {
+	buffer string
+	prefix string // tier 1: candidate must start with this and continue past it
+	head   string // tier 2: candidate's first word must equal this
+}
+
+// A candidate equal to the buffer never survives: its ghost text is empty.
+func (a anchor) allows(cmd string) bool {
+	switch {
+	case a.prefix != "":
+		return len(cmd) > len(a.prefix) && strings.HasPrefix(cmd, a.prefix)
+	case a.head != "":
+		return cmd != a.buffer && commandWord(cmd) == a.head
+	default:
+		return true
+	}
+}
+
+// newAnchor takes the tightest anchor the candidates support, else none, which
+// leaves `gco` → `git checkout` to fuzzy matching. Tier 2 skips a candidate
+// equal to the buffer, or an alias like `gco` would anchor to itself.
+func newAnchor(candidates []store.CommandStat, buffer string) anchor {
+	if buffer == "" {
+		return anchor{}
+	}
+
+	head := commandWord(buffer)
+	headKnown := false
+
+	for _, c := range candidates {
+		if len(c.Command) > len(buffer) && strings.HasPrefix(c.Command, buffer) {
+			return anchor{buffer: buffer, prefix: buffer}
+		}
+		if !headKnown && head != "" && c.Command != buffer && commandWord(c.Command) == head {
+			headKnown = true
+		}
+	}
+
+	if headKnown {
+		return anchor{buffer: buffer, head: head}
+	}
+	return anchor{}
+}
+
+func commandWord(s string) string {
+	if i := strings.IndexByte(s, ' '); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
 // computeFuzzy returns the per-candidate fuzzy score and how many candidates
 // scored above zero, so the caller can size its result slice to the survivors
 // rather than to the whole history.
@@ -236,11 +289,17 @@ func computeFuzzy(candidates []store.CommandStat, buffer string, fuzziness Fuzzy
 	gapCap := maxGap(fuzziness)
 	filterByGap := len(buffer) > 1
 
+	// Before the normalisation below, so anchored-out commands score zero.
+	anch := newAnchor(candidates, buffer)
+
 	matched := make([]bool, len(candidates))
 	raw := make([]int, len(candidates))
 	first := true
 	var min, max int
 	for _, m := range matches {
+		if !anch.allows(candidates[m.Index].Command) {
+			continue
+		}
 		if filterByGap && maxConsecutiveGap(m.MatchedIndexes) > gapCap {
 			continue
 		}
@@ -259,7 +318,7 @@ func computeFuzzy(candidates []store.CommandStat, buffer string, fuzziness Fuzzy
 		}
 	}
 	if first {
-		// Every match was filtered out by the gap cap.
+		// Every match was filtered out by the anchor or the gap cap.
 		return scores, 0
 	}
 

--- a/internal/scorer/scorer_test.go
+++ b/internal/scorer/scorer_test.go
@@ -390,6 +390,137 @@ func TestRank_GapFilter(t *testing.T) {
 	})
 }
 
+// A buffer that is itself something the user has run never gets an unrelated
+// command suggested back.
+func TestRank_Anchor(t *testing.T) {
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+
+	hasCmd := func(rs []Result, cmd string) bool {
+		for _, r := range rs {
+			if r.Command == cmd {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("literal prefix drops the fuzzy interloper", func(t *testing.T) {
+		candidates := []store.CommandStat{
+			{Command: "claude --resume", Count: 500, LastUsed: now},
+			{Command: "cd Devel/personal/deja", Count: 5, LastUsed: now.Add(-72 * time.Hour)},
+		}
+
+		got := Rank(candidates, "cd ", "", "", nil, nil, now, FuzzyLoose)
+
+		if len(got) != 1 || got[0].Command != "cd Devel/personal/deja" {
+			t.Fatalf("want only the cd continuation, got %+v", got)
+		}
+	})
+
+	t.Run("prefix anchor excludes the buffer itself", func(t *testing.T) {
+		candidates := []store.CommandStat{
+			{Command: "cd", Count: 900, LastUsed: now},
+			{Command: "cd Devel/personal/deja", Count: 5, LastUsed: now.Add(-72 * time.Hour)},
+		}
+
+		got := Rank(candidates, "cd", "", "", nil, nil, now, FuzzySmart)
+
+		if len(got) != 1 || got[0].Command != "cd Devel/personal/deja" {
+			t.Fatalf("want only the cd continuation, got %+v", got)
+		}
+	})
+
+	t.Run("prefix anchor keeps a longer word that continues the text", func(t *testing.T) {
+		candidates := []store.CommandStat{
+			{Command: "ls -la", Count: 40, LastUsed: now},
+			{Command: "lsof -i", Count: 3, LastUsed: now},
+			{Command: "claude --resume", Count: 500, LastUsed: now},
+		}
+
+		got := Rank(candidates, "ls", "", "", nil, nil, now, FuzzySmart)
+
+		for _, want := range []string{"ls -la", "lsof -i"} {
+			if !hasCmd(got, want) {
+				t.Errorf("expected %q in results, got %+v", want, got)
+			}
+		}
+		if hasCmd(got, "claude --resume") {
+			t.Errorf("did not expect the interloper, got %+v", got)
+		}
+	})
+
+	t.Run("command word anchors a typo to its own family", func(t *testing.T) {
+		candidates := []store.CommandStat{
+			{Command: "gitk --checkout", Count: 200, LastUsed: now},
+			{Command: "git checkout main", Count: 4, LastUsed: now.Add(-48 * time.Hour)},
+			{Command: "git push", Count: 50, LastUsed: now},
+		}
+
+		got := Rank(candidates, "git ceckout", "", "", nil, nil, now, FuzzySmart)
+
+		if !hasCmd(got, "git checkout main") {
+			t.Errorf("expected the in-family match, got %+v", got)
+		}
+		if hasCmd(got, "gitk --checkout") {
+			t.Errorf("did not expect a different command word, got %+v", got)
+		}
+	})
+
+	t.Run("command word anchor covers a case difference tier 1 misses", func(t *testing.T) {
+		// The fuzzy library matches case-insensitively; the prefix test does not.
+		candidates := []store.CommandStat{
+			{Command: "codex --dangerous", Count: 300, LastUsed: now},
+			{Command: "cd Devel/personal", Count: 5, LastUsed: now.Add(-72 * time.Hour)},
+		}
+
+		got := Rank(candidates, "cd d", "", "", nil, nil, now, FuzzySmart)
+
+		if len(got) != 1 || got[0].Command != "cd Devel/personal" {
+			t.Fatalf("want only the cd continuation, got %+v", got)
+		}
+	})
+
+	t.Run("anchored buffer with no in-family match suggests nothing", func(t *testing.T) {
+		candidates := []store.CommandStat{
+			{Command: "git push", Count: 50, LastUsed: now},
+			{Command: "claude --resume", Count: 500, LastUsed: now},
+		}
+
+		got := Rank(candidates, "git zzz", "", "", nil, nil, now, FuzzySmart)
+
+		if len(got) != 0 {
+			t.Errorf("want no suggestion rather than a fuzzy stand-in, got %+v", got)
+		}
+	})
+
+	t.Run("an abbreviation still expands even when recorded itself", func(t *testing.T) {
+		// Anchoring on the alias itself would expand to an empty ghost.
+		candidates := []store.CommandStat{
+			{Command: "gco", Count: 20, LastUsed: now},
+			{Command: "git checkout main", Count: 5, LastUsed: now},
+		}
+
+		got := Rank(candidates, "gco", "", "", nil, nil, now, FuzzySmart)
+
+		if !hasCmd(got, "git checkout main") {
+			t.Errorf("expected the fuzzy expansion, got %+v", got)
+		}
+	})
+
+	t.Run("empty buffer is never anchored", func(t *testing.T) {
+		candidates := []store.CommandStat{
+			{Command: "cd Devel/personal", Count: 5, LastUsed: now},
+			{Command: "claude --resume", Count: 500, LastUsed: now},
+		}
+
+		got := Rank(candidates, "", "", "", nil, nil, now, FuzzySmart)
+
+		if len(got) != len(candidates) {
+			t.Errorf("want all %d candidates, got %+v", len(candidates), got)
+		}
+	})
+}
+
 func findResult(rs []Result, cmd string) *Result {
 	for i := range rs {
 		if rs[i].Command == cmd {


### PR DESCRIPTION
## Summary

A command you were not typing toward can no longer win the prompt on
frecency alone. When the line matches something you have actually run,
only real continuations of it are offered — or nothing.

Before, typing `cd ` in `$HOME` suggested `claude --resume`: `cd ` is a
subsequence of it, and its frecency and directory affinity outrank every
real `cd …`. Fuzzy expansion still applies when the line is not a
command you have run, so `gco` → `git checkout` is unchanged. The flip
side is that a line with nothing left to match shows no ghost text.

Top suggestion over a real 3,566-command history, ranked from `$HOME`:

| buffer | before | after |
|---|---|---|
| `cd` | `claude` | `cd Devel` |
| `cd ` | `claude --resume` | `cd ..` |
| `gco` | `git checkout main` | unchanged |

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `BREAKING CHANGE:` footer)
- [ ] Docs / chore / refactor / test / ci

## Test plan

- [x] `go test -race ./...` passes locally
- [x] `go vet ./...` clean
- [x] Tests added — `TestRank_Anchor`, 8 subtests
- [x] Manually verified the buffers above against a live daemon; the
      typing, accept, and alt-picker paths are untouched by this diff
