### PR TITLE
ci: run the test job on macOS as well as ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,11 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     env:
       CGO_ENABLED: "1"
     steps:


### PR DESCRIPTION
Follows from your note on #109: *"The ci didn't failed because runs on ubuntu only."*

## Why

`sun_path` holds 104 bytes on macOS against 108 on Linux, and `t.TempDir` returns paths long enough there to push a unix socket over it. That is enough of a gap for a test to pass in CI and fail on your Mac, which is exactly how the fixtures in #109 and #110 reached you. Nothing catches that class today.

deja ships darwin binaries, so the platform seems worth a runner.

## What

```yaml
strategy:
  fail-fast: false
  matrix:
    os: [ubuntu-latest, macos-latest]
runs-on: ${{ matrix.os }}
```

`fail-fast: false` so one platform failing still reports the other, instead of cancelling it.

## One consequence worth your explicit agreement

`release.yml` calls this workflow and `goreleaser` has `needs: test`, so **a red macOS job now blocks a release**, where before it could not. For a project shipping darwin builds I think that is the right way round, but it is a change in behaviour rather than a reporting-only one, so I would rather flag it than have you find it at release time. Say the word and I will scope the matrix to `pull_request`/`push` and leave `workflow_call` on ubuntu alone.

## What I could not verify

I have no Mac, so I cannot tell you this is green before you run it — this PR's own CI run is the test. What I can say is that the full suite passes `go test -race ./...` on Linux with `$TMPDIR` padded to macOS's length, on `main` and on both fix branches, which covers the path-length class specifically but not anything else macOS-shaped.

Kept separate from #109 and #110 on purpose: if something unrelated turns out to fail on macOS, that should not block two bug fixes.