### PR TITLE
fix: stop zinit from running install.sh inside the shell (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ deja import && exec zsh
 If you use [zinit](https://github.com/zdharma-continuum/zinit), add this to your `.zshrc`:
 
 ```zsh
-zinit ice wait"0" lucid depth=1
+zinit ice wait"0" lucid depth=1 pick"deja.plugin.zsh"
 zinit light Giammarco-Ferranti/deja
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env sh
+
+# zinit (and other zsh plugin managers) may source this file because the
+# repo root matches `*.sh`. `set -eu` would then apply to the surrounding
+# shell and trip zinit's turbo scheduler on unset `ZINIT[lro-data]`.
+# See https://github.com/Giammarco-Ferranti/deja/issues/67
+if [ -n "${ZSH_VERSION:-}" ]; then
+  case "${ZSH_EVAL_CONTEXT:-}" in
+    *:file*)
+      return 0 2>/dev/null || exit 0
+      ;;
+  esac
+fi
+
 set -eu
 
 REPO="Giammarco-Ferranti/deja"


### PR DESCRIPTION
zinit can source the repo-root *.sh file; set -eu then trips the turbo scheduler on unset ZINIT keys. Return when sourced from zsh, and pin deja.plugin.zsh in the README.

<!--
PR title should follow Conventional Commits:
  feat: ...    fix: ...    chore: ...    docs: ...    refactor: ...    test: ...    ci: ...
Use `feat!:` or a `BREAKING CHANGE:` footer for breaking changes.
-->

## Summary

<!-- What does this change and why? Link any related issue (`Closes #N`). -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `BREAKING CHANGE:` footer)
- [ ] Docs / chore / refactor / test / ci

## Test plan

- [x] `go test -race ./...` passes locally
- [x] `go vet ./...` clean
- [ ] Added or updated tests for the change
- [ ] Manually verified the shell integration (if relevant): typing, accept, alt-picker

## Notes for reviewers

<!-- Anything subtle, risky, or worth a second look. -->
