### PR TITLE
fix: guard printed source line against missing init.zsh

### DIFF
--- a/cmd/deja/init.go
+++ b/cmd/deja/init.go
@@ -66,7 +66,7 @@ func runInit(args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("source '%s'\n", initPath)
+	fmt.Printf("[[ -r '%s' ]] && builtin source '%s'\n", initPath, initPath)
 }
 
 // binaryStamp identifies a build of the deja binary by its stat metadata, in the

--- a/cmd/deja/init_test.go
+++ b/cmd/deja/init_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -122,5 +124,36 @@ func TestWriteInitScript_BakesBinaryStamp(t *testing.T) {
 	}
 	if fi.Mode().Perm() != 0o644 {
 		t.Errorf("mode = %v, want 0644", fi.Mode().Perm())
+	}
+}
+
+// The printed line is eval'd by every shell, and the daemon may purge
+// ~/.local/share/deja between shells. A bare `source <missing>` would error
+// on every startup, so the line must degrade to a silent skip instead.
+func TestRunInit_PrintsGuardedSourceLine(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	runInit([]string{"zsh"})
+	w.Close()
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+
+	initPath := filepath.Join(home, ".local", "share", "deja", "init.zsh")
+	want := fmt.Sprintf("[[ -r '%s' ]] && builtin source '%s'\n", initPath, initPath)
+	if string(out) != want {
+		t.Errorf("runInit printed %q, want %q", out, want)
+	}
+	if _, err := os.Stat(initPath); err != nil {
+		t.Errorf("init script was not written to %s: %v", initPath, err)
 	}
 }


### PR DESCRIPTION
## Symptom

`eval "$(deja init zsh)"` caches a bare `source ~/.local/share/deja/init.zsh` line. The cached line is evaluated by shells that never ran the generator, and nothing revalidates the file's existence at source time — a bare `source` of a missing file errors (exit 127), so every new shell errors on startup instead of degrading gracefully.

Discovered via the zinit `eval` cache (the baked line outliving the file), but any skew between cache-build time and file presence surfaces it identically: a carried-over zinit dir on a fresh machine, a manual history reset (`rm -rf ~/.local/share/deja`), or a failed generation.

## Mechanism

`runInit` (`cmd/deja/init.go`) rewrites `init.zsh` on every invocation, but nothing guarantees the file still exists when a *later* shell sources the cached line.

## Fix (one line)

Print a readability-guarded source line instead (`builtin` so no alias or function named `source` can intercept it):

```zsh
[[ -r ~/.local/share/deja/init.zsh ]] && builtin source ~/.local/share/deja/init.zsh
```

A missing file now skips silently; the background self-heal regenerates it as before.

## Tests

- New `TestRunInit_PrintsGuardedSourceLine` (`cmd/deja/init_test.go`): sandboxed `HOME`, captures stdout, asserts the exact guarded line and that the script was written.
- `go test -race ./...` — all packages pass. `go vet ./...` — clean.